### PR TITLE
refactor(cli): use bound API methods in command execution

### DIFF
--- a/bin/generate/cli.py
+++ b/bin/generate/cli.py
@@ -496,7 +496,7 @@ def generate_command_function(
     method_name = to_snake_case(operation_id)
     lines.append("    client: 'AsyncClient' = ctx.obj['client']")
     lines.append(
-        f"    result = run_command(client.{tag_attr}.{method_name}, ctx, **kwargs)"
+        f"    result = run_command(client.{tag_attr}.{method_name}, ctx=ctx, **kwargs)"
     )
 
     # Print result

--- a/bin/generate/cli.py
+++ b/bin/generate/cli.py
@@ -498,7 +498,7 @@ def generate_command_function(
     # Call method
     method_name = to_snake_case(operation_id)
     lines.append(
-        f"    result = run_command(client, client.{tag_attr}, '{method_name}', ctx, **kwargs)"
+        f"    result = run_command(client.{tag_attr}, '{method_name}', ctx, **kwargs)"
     )
 
     # Print result

--- a/bin/generate/cli.py
+++ b/bin/generate/cli.py
@@ -492,13 +492,11 @@ def generate_command_function(
                     # openapi-generator doesn't generate a model for multipart/form-data, but use kwargs
                     # instead we simply merge the json_data into the kwargs
                     lines.append("    kwargs.update(json_data)")
-    # Get client and API group
-    lines.append("    client: 'AsyncClient' = ctx.obj['client']")
-
     # Call method
     method_name = to_snake_case(operation_id)
+    lines.append("    client: 'AsyncClient' = ctx.obj['client']")
     lines.append(
-        f"    result = run_command(client.{tag_attr}, '{method_name}', ctx, **kwargs)"
+        f"    result = run_command(client.{tag_attr}.{method_name}, ctx, **kwargs)"
     )
 
     # Print result

--- a/immichpy/cli/commands/activities.py
+++ b/immichpy/cli/commands/activities.py
@@ -43,7 +43,7 @@ def create_activity(
     activity_create_dto = ActivityCreateDto.model_validate(json_data)
     kwargs["activity_create_dto"] = activity_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.activities, "create_activity", ctx, **kwargs)
+    result = run_command(client.activities, "create_activity", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -59,7 +59,7 @@ def delete_activity(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.activities, "delete_activity", ctx, **kwargs)
+    result = run_command(client.activities, "delete_activity", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -93,7 +93,7 @@ def get_activities(
     if user_id is not None:
         kwargs["user_id"] = user_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.activities, "get_activities", ctx, **kwargs)
+    result = run_command(client.activities, "get_activities", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -116,7 +116,5 @@ def get_activity_statistics(
     if asset_id is not None:
         kwargs["asset_id"] = asset_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.activities, "get_activity_statistics", ctx, **kwargs
-    )
+    result = run_command(client.activities, "get_activity_statistics", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/activities.py
+++ b/immichpy/cli/commands/activities.py
@@ -43,7 +43,7 @@ def create_activity(
     activity_create_dto = ActivityCreateDto.model_validate(json_data)
     kwargs["activity_create_dto"] = activity_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities, "create_activity", ctx, **kwargs)
+    result = run_command(client.activities.create_activity, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -59,7 +59,7 @@ def delete_activity(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities, "delete_activity", ctx, **kwargs)
+    result = run_command(client.activities.delete_activity, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -93,7 +93,7 @@ def get_activities(
     if user_id is not None:
         kwargs["user_id"] = user_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities, "get_activities", ctx, **kwargs)
+    result = run_command(client.activities.get_activities, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -116,5 +116,5 @@ def get_activity_statistics(
     if asset_id is not None:
         kwargs["asset_id"] = asset_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities, "get_activity_statistics", ctx, **kwargs)
+    result = run_command(client.activities.get_activity_statistics, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/activities.py
+++ b/immichpy/cli/commands/activities.py
@@ -43,7 +43,7 @@ def create_activity(
     activity_create_dto = ActivityCreateDto.model_validate(json_data)
     kwargs["activity_create_dto"] = activity_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities.create_activity, ctx, **kwargs)
+    result = run_command(client.activities.create_activity, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -59,7 +59,7 @@ def delete_activity(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities.delete_activity, ctx, **kwargs)
+    result = run_command(client.activities.delete_activity, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -93,7 +93,7 @@ def get_activities(
     if user_id is not None:
         kwargs["user_id"] = user_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities.get_activities, ctx, **kwargs)
+    result = run_command(client.activities.get_activities, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -116,5 +116,5 @@ def get_activity_statistics(
     if asset_id is not None:
         kwargs["asset_id"] = asset_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.activities.get_activity_statistics, ctx, **kwargs)
+    result = run_command(client.activities.get_activity_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/albums.py
+++ b/immichpy/cli/commands/albums.py
@@ -40,7 +40,7 @@ def add_assets_to_album(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.add_assets_to_album, ctx, **kwargs)
+    result = run_command(client.albums.add_assets_to_album, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -67,7 +67,7 @@ def add_assets_to_albums(
     albums_add_assets_dto = AlbumsAddAssetsDto.model_validate(json_data)
     kwargs["albums_add_assets_dto"] = albums_add_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.add_assets_to_albums, ctx, **kwargs)
+    result = run_command(client.albums.add_assets_to_albums, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -95,7 +95,7 @@ As a JSON string""",
     add_users_dto = AddUsersDto.model_validate(json_data)
     kwargs["add_users_dto"] = add_users_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.add_users_to_album, ctx, **kwargs)
+    result = run_command(client.albums.add_users_to_album, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -134,7 +134,7 @@ As a JSON string""",
     create_album_dto = CreateAlbumDto.model_validate(json_data)
     kwargs["create_album_dto"] = create_album_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.create_album, ctx, **kwargs)
+    result = run_command(client.albums.create_album, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -150,7 +150,7 @@ def delete_album(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.delete_album, ctx, **kwargs)
+    result = run_command(client.albums.delete_album, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def get_album_info(
     if without_assets is not None:
         kwargs["without_assets"] = without_assets.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.get_album_info, ctx, **kwargs)
+    result = run_command(client.albums.get_album_info, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -191,7 +191,7 @@ def get_album_statistics(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.get_album_statistics, ctx, **kwargs)
+    result = run_command(client.albums.get_album_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -219,7 +219,7 @@ def get_all_albums(
     if shared is not None:
         kwargs["shared"] = shared.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.get_all_albums, ctx, **kwargs)
+    result = run_command(client.albums.get_all_albums, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -242,7 +242,7 @@ def remove_asset_from_album(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.remove_asset_from_album, ctx, **kwargs)
+    result = run_command(client.albums.remove_asset_from_album, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -260,7 +260,7 @@ def remove_user_from_album(
     kwargs["id"] = id
     kwargs["user_id"] = user_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.remove_user_from_album, ctx, **kwargs)
+    result = run_command(client.albums.remove_user_from_album, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -302,7 +302,7 @@ def update_album_info(
     update_album_dto = UpdateAlbumDto.model_validate(json_data)
     kwargs["update_album_dto"] = update_album_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.update_album_info, ctx, **kwargs)
+    result = run_command(client.albums.update_album_info, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -325,5 +325,5 @@ def update_album_user(
     update_album_user_dto = UpdateAlbumUserDto.model_validate(json_data)
     kwargs["update_album_user_dto"] = update_album_user_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums.update_album_user, ctx, **kwargs)
+    result = run_command(client.albums.update_album_user, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/albums.py
+++ b/immichpy/cli/commands/albums.py
@@ -40,7 +40,7 @@ def add_assets_to_album(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "add_assets_to_album", ctx, **kwargs)
+    result = run_command(client.albums, "add_assets_to_album", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -67,7 +67,7 @@ def add_assets_to_albums(
     albums_add_assets_dto = AlbumsAddAssetsDto.model_validate(json_data)
     kwargs["albums_add_assets_dto"] = albums_add_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "add_assets_to_albums", ctx, **kwargs)
+    result = run_command(client.albums, "add_assets_to_albums", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -95,7 +95,7 @@ As a JSON string""",
     add_users_dto = AddUsersDto.model_validate(json_data)
     kwargs["add_users_dto"] = add_users_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "add_users_to_album", ctx, **kwargs)
+    result = run_command(client.albums, "add_users_to_album", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -134,7 +134,7 @@ As a JSON string""",
     create_album_dto = CreateAlbumDto.model_validate(json_data)
     kwargs["create_album_dto"] = create_album_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "create_album", ctx, **kwargs)
+    result = run_command(client.albums, "create_album", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -150,7 +150,7 @@ def delete_album(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "delete_album", ctx, **kwargs)
+    result = run_command(client.albums, "delete_album", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def get_album_info(
     if without_assets is not None:
         kwargs["without_assets"] = without_assets.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "get_album_info", ctx, **kwargs)
+    result = run_command(client.albums, "get_album_info", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -191,7 +191,7 @@ def get_album_statistics(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "get_album_statistics", ctx, **kwargs)
+    result = run_command(client.albums, "get_album_statistics", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -219,7 +219,7 @@ def get_all_albums(
     if shared is not None:
         kwargs["shared"] = shared.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "get_all_albums", ctx, **kwargs)
+    result = run_command(client.albums, "get_all_albums", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -242,9 +242,7 @@ def remove_asset_from_album(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.albums, "remove_asset_from_album", ctx, **kwargs
-    )
+    result = run_command(client.albums, "remove_asset_from_album", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -262,7 +260,7 @@ def remove_user_from_album(
     kwargs["id"] = id
     kwargs["user_id"] = user_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "remove_user_from_album", ctx, **kwargs)
+    result = run_command(client.albums, "remove_user_from_album", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -304,7 +302,7 @@ def update_album_info(
     update_album_dto = UpdateAlbumDto.model_validate(json_data)
     kwargs["update_album_dto"] = update_album_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "update_album_info", ctx, **kwargs)
+    result = run_command(client.albums, "update_album_info", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -327,5 +325,5 @@ def update_album_user(
     update_album_user_dto = UpdateAlbumUserDto.model_validate(json_data)
     kwargs["update_album_user_dto"] = update_album_user_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.albums, "update_album_user", ctx, **kwargs)
+    result = run_command(client.albums, "update_album_user", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/albums.py
+++ b/immichpy/cli/commands/albums.py
@@ -40,7 +40,7 @@ def add_assets_to_album(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "add_assets_to_album", ctx, **kwargs)
+    result = run_command(client.albums.add_assets_to_album, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -67,7 +67,7 @@ def add_assets_to_albums(
     albums_add_assets_dto = AlbumsAddAssetsDto.model_validate(json_data)
     kwargs["albums_add_assets_dto"] = albums_add_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "add_assets_to_albums", ctx, **kwargs)
+    result = run_command(client.albums.add_assets_to_albums, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -95,7 +95,7 @@ As a JSON string""",
     add_users_dto = AddUsersDto.model_validate(json_data)
     kwargs["add_users_dto"] = add_users_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "add_users_to_album", ctx, **kwargs)
+    result = run_command(client.albums.add_users_to_album, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -134,7 +134,7 @@ As a JSON string""",
     create_album_dto = CreateAlbumDto.model_validate(json_data)
     kwargs["create_album_dto"] = create_album_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "create_album", ctx, **kwargs)
+    result = run_command(client.albums.create_album, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -150,7 +150,7 @@ def delete_album(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "delete_album", ctx, **kwargs)
+    result = run_command(client.albums.delete_album, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def get_album_info(
     if without_assets is not None:
         kwargs["without_assets"] = without_assets.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "get_album_info", ctx, **kwargs)
+    result = run_command(client.albums.get_album_info, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -191,7 +191,7 @@ def get_album_statistics(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "get_album_statistics", ctx, **kwargs)
+    result = run_command(client.albums.get_album_statistics, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -219,7 +219,7 @@ def get_all_albums(
     if shared is not None:
         kwargs["shared"] = shared.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "get_all_albums", ctx, **kwargs)
+    result = run_command(client.albums.get_all_albums, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -242,7 +242,7 @@ def remove_asset_from_album(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "remove_asset_from_album", ctx, **kwargs)
+    result = run_command(client.albums.remove_asset_from_album, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -260,7 +260,7 @@ def remove_user_from_album(
     kwargs["id"] = id
     kwargs["user_id"] = user_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "remove_user_from_album", ctx, **kwargs)
+    result = run_command(client.albums.remove_user_from_album, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -302,7 +302,7 @@ def update_album_info(
     update_album_dto = UpdateAlbumDto.model_validate(json_data)
     kwargs["update_album_dto"] = update_album_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "update_album_info", ctx, **kwargs)
+    result = run_command(client.albums.update_album_info, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -325,5 +325,5 @@ def update_album_user(
     update_album_user_dto = UpdateAlbumUserDto.model_validate(json_data)
     kwargs["update_album_user_dto"] = update_album_user_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.albums, "update_album_user", ctx, **kwargs)
+    result = run_command(client.albums.update_album_user, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/api_keys.py
+++ b/immichpy/cli/commands/api_keys.py
@@ -36,7 +36,7 @@ def create_api_key(
     api_key_create_dto = APIKeyCreateDto.model_validate(json_data)
     kwargs["api_key_create_dto"] = api_key_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.api_keys, "create_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys, "create_api_key", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -52,7 +52,7 @@ def delete_api_key(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.api_keys, "delete_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys, "delete_api_key", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def get_api_key(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.api_keys, "get_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys, "get_api_key", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -82,7 +82,7 @@ def get_api_keys(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.api_keys, "get_api_keys", ctx, **kwargs)
+    result = run_command(client.api_keys, "get_api_keys", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_my_api_key(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.api_keys, "get_my_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys, "get_my_api_key", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -123,5 +123,5 @@ def update_api_key(
     api_key_update_dto = APIKeyUpdateDto.model_validate(json_data)
     kwargs["api_key_update_dto"] = api_key_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.api_keys, "update_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys, "update_api_key", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/api_keys.py
+++ b/immichpy/cli/commands/api_keys.py
@@ -36,7 +36,7 @@ def create_api_key(
     api_key_create_dto = APIKeyCreateDto.model_validate(json_data)
     kwargs["api_key_create_dto"] = api_key_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys, "create_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys.create_api_key, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -52,7 +52,7 @@ def delete_api_key(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys, "delete_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys.delete_api_key, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def get_api_key(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys, "get_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys.get_api_key, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -82,7 +82,7 @@ def get_api_keys(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys, "get_api_keys", ctx, **kwargs)
+    result = run_command(client.api_keys.get_api_keys, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_my_api_key(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys, "get_my_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys.get_my_api_key, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -123,5 +123,5 @@ def update_api_key(
     api_key_update_dto = APIKeyUpdateDto.model_validate(json_data)
     kwargs["api_key_update_dto"] = api_key_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys, "update_api_key", ctx, **kwargs)
+    result = run_command(client.api_keys.update_api_key, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/api_keys.py
+++ b/immichpy/cli/commands/api_keys.py
@@ -36,7 +36,7 @@ def create_api_key(
     api_key_create_dto = APIKeyCreateDto.model_validate(json_data)
     kwargs["api_key_create_dto"] = api_key_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys.create_api_key, ctx, **kwargs)
+    result = run_command(client.api_keys.create_api_key, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -52,7 +52,7 @@ def delete_api_key(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys.delete_api_key, ctx, **kwargs)
+    result = run_command(client.api_keys.delete_api_key, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def get_api_key(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys.get_api_key, ctx, **kwargs)
+    result = run_command(client.api_keys.get_api_key, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -82,7 +82,7 @@ def get_api_keys(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys.get_api_keys, ctx, **kwargs)
+    result = run_command(client.api_keys.get_api_keys, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_my_api_key(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys.get_my_api_key, ctx, **kwargs)
+    result = run_command(client.api_keys.get_my_api_key, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -123,5 +123,5 @@ def update_api_key(
     api_key_update_dto = APIKeyUpdateDto.model_validate(json_data)
     kwargs["api_key_update_dto"] = api_key_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.api_keys.update_api_key, ctx, **kwargs)
+    result = run_command(client.api_keys.update_api_key, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/assets.py
+++ b/immichpy/cli/commands/assets.py
@@ -41,7 +41,7 @@ As a JSON string""",
     asset_bulk_upload_check_dto = AssetBulkUploadCheckDto.model_validate(json_data)
     kwargs["asset_bulk_upload_check_dto"] = asset_bulk_upload_check_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "check_bulk_upload", ctx, **kwargs)
+    result = run_command(client.assets.check_bulk_upload, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +64,7 @@ def check_existing_assets(
     check_existing_assets_dto = CheckExistingAssetsDto.model_validate(json_data)
     kwargs["check_existing_assets_dto"] = check_existing_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "check_existing_assets", ctx, **kwargs)
+    result = run_command(client.assets.check_existing_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -110,7 +110,7 @@ def copy_asset(
     asset_copy_dto = AssetCopyDto.model_validate(json_data)
     kwargs["asset_copy_dto"] = asset_copy_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "copy_asset", ctx, **kwargs)
+    result = run_command(client.assets.copy_asset, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -128,7 +128,7 @@ def delete_asset_metadata(
     kwargs["id"] = id
     kwargs["key"] = key
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "delete_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets.delete_asset_metadata, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -152,7 +152,7 @@ def delete_assets(
     asset_bulk_delete_dto = AssetBulkDeleteDto.model_validate(json_data)
     kwargs["asset_bulk_delete_dto"] = asset_bulk_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "delete_assets", ctx, **kwargs)
+    result = run_command(client.assets.delete_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -182,7 +182,7 @@ As a JSON string""",
     )
     kwargs["asset_metadata_bulk_delete_dto"] = asset_metadata_bulk_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "delete_bulk_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets.delete_bulk_asset_metadata, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -209,7 +209,7 @@ def download_asset(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "download_asset", ctx, **kwargs)
+    result = run_command(client.assets.download_asset, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -237,7 +237,7 @@ As a JSON string""",
     asset_edits_create_dto = AssetEditsCreateDto.model_validate(json_data)
     kwargs["asset_edits_create_dto"] = asset_edits_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "edit_asset", ctx, **kwargs)
+    result = run_command(client.assets.edit_asset, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -255,9 +255,7 @@ def get_all_user_assets_by_device_id(
     kwargs = {}
     kwargs["device_id"] = device_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.assets, "get_all_user_assets_by_device_id", ctx, **kwargs
-    )
+    result = run_command(client.assets.get_all_user_assets_by_device_id, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -273,7 +271,7 @@ def get_asset_edits(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "get_asset_edits", ctx, **kwargs)
+    result = run_command(client.assets.get_asset_edits, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -295,7 +293,7 @@ def get_asset_info(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "get_asset_info", ctx, **kwargs)
+    result = run_command(client.assets.get_asset_info, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -311,7 +309,7 @@ def get_asset_metadata(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "get_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets.get_asset_metadata, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -331,7 +329,7 @@ def get_asset_metadata_by_key(
     kwargs["id"] = id
     kwargs["key"] = key
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "get_asset_metadata_by_key", ctx, **kwargs)
+    result = run_command(client.assets.get_asset_metadata_by_key, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -347,7 +345,7 @@ def get_asset_ocr(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "get_asset_ocr", ctx, **kwargs)
+    result = run_command(client.assets.get_asset_ocr, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -376,7 +374,7 @@ def get_asset_statistics(
     if visibility is not None:
         kwargs["visibility"] = visibility
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "get_asset_statistics", ctx, **kwargs)
+    result = run_command(client.assets.get_asset_statistics, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -395,7 +393,7 @@ def get_random(
     if count is not None:
         kwargs["count"] = count
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "get_random", ctx, **kwargs)
+    result = run_command(client.assets.get_random, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -417,7 +415,7 @@ def play_asset_video(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "play_asset_video", ctx, **kwargs)
+    result = run_command(client.assets.play_asset_video, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -433,7 +431,7 @@ def remove_asset_edits(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "remove_asset_edits", ctx, **kwargs)
+    result = run_command(client.assets.remove_asset_edits, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -483,7 +481,7 @@ def replace_asset(
         set_nested(json_data, ["filename"], filename)
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "replace_asset", ctx, **kwargs)
+    result = run_command(client.assets.replace_asset, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -504,7 +502,7 @@ def run_asset_jobs(
     asset_jobs_dto = AssetJobsDto.model_validate(json_data)
     kwargs["asset_jobs_dto"] = asset_jobs_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "run_asset_jobs", ctx, **kwargs)
+    result = run_command(client.assets.run_asset_jobs, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -567,7 +565,7 @@ def update_asset(
     update_asset_dto = UpdateAssetDto.model_validate(json_data)
     kwargs["update_asset_dto"] = update_asset_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "update_asset", ctx, **kwargs)
+    result = run_command(client.assets.update_asset, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -595,7 +593,7 @@ As a JSON string""",
     asset_metadata_upsert_dto = AssetMetadataUpsertDto.model_validate(json_data)
     kwargs["asset_metadata_upsert_dto"] = asset_metadata_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "update_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets.update_asset_metadata, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -668,7 +666,7 @@ def update_assets(
     asset_bulk_update_dto = AssetBulkUpdateDto.model_validate(json_data)
     kwargs["asset_bulk_update_dto"] = asset_bulk_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "update_assets", ctx, **kwargs)
+    result = run_command(client.assets.update_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -698,7 +696,7 @@ As a JSON string""",
     )
     kwargs["asset_metadata_bulk_upsert_dto"] = asset_metadata_bulk_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "update_bulk_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets.update_bulk_asset_metadata, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -785,7 +783,7 @@ As a JSON string""",
         set_nested(json_data, ["visibility"], visibility)
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "upload_asset", ctx, **kwargs)
+    result = run_command(client.assets.upload_asset, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -817,5 +815,5 @@ def view_asset(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets, "view_asset", ctx, **kwargs)
+    result = run_command(client.assets.view_asset, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/assets.py
+++ b/immichpy/cli/commands/assets.py
@@ -41,7 +41,7 @@ As a JSON string""",
     asset_bulk_upload_check_dto = AssetBulkUploadCheckDto.model_validate(json_data)
     kwargs["asset_bulk_upload_check_dto"] = asset_bulk_upload_check_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "check_bulk_upload", ctx, **kwargs)
+    result = run_command(client.assets, "check_bulk_upload", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +64,7 @@ def check_existing_assets(
     check_existing_assets_dto = CheckExistingAssetsDto.model_validate(json_data)
     kwargs["check_existing_assets_dto"] = check_existing_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "check_existing_assets", ctx, **kwargs)
+    result = run_command(client.assets, "check_existing_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -110,7 +110,7 @@ def copy_asset(
     asset_copy_dto = AssetCopyDto.model_validate(json_data)
     kwargs["asset_copy_dto"] = asset_copy_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "copy_asset", ctx, **kwargs)
+    result = run_command(client.assets, "copy_asset", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -128,7 +128,7 @@ def delete_asset_metadata(
     kwargs["id"] = id
     kwargs["key"] = key
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "delete_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets, "delete_asset_metadata", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -152,7 +152,7 @@ def delete_assets(
     asset_bulk_delete_dto = AssetBulkDeleteDto.model_validate(json_data)
     kwargs["asset_bulk_delete_dto"] = asset_bulk_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "delete_assets", ctx, **kwargs)
+    result = run_command(client.assets, "delete_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -182,9 +182,7 @@ As a JSON string""",
     )
     kwargs["asset_metadata_bulk_delete_dto"] = asset_metadata_bulk_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.assets, "delete_bulk_asset_metadata", ctx, **kwargs
-    )
+    result = run_command(client.assets, "delete_bulk_asset_metadata", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -211,7 +209,7 @@ def download_asset(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "download_asset", ctx, **kwargs)
+    result = run_command(client.assets, "download_asset", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -239,7 +237,7 @@ As a JSON string""",
     asset_edits_create_dto = AssetEditsCreateDto.model_validate(json_data)
     kwargs["asset_edits_create_dto"] = asset_edits_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "edit_asset", ctx, **kwargs)
+    result = run_command(client.assets, "edit_asset", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -258,7 +256,7 @@ def get_all_user_assets_by_device_id(
     kwargs["device_id"] = device_id
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.assets, "get_all_user_assets_by_device_id", ctx, **kwargs
+        client.assets, "get_all_user_assets_by_device_id", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -275,7 +273,7 @@ def get_asset_edits(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "get_asset_edits", ctx, **kwargs)
+    result = run_command(client.assets, "get_asset_edits", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -297,7 +295,7 @@ def get_asset_info(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "get_asset_info", ctx, **kwargs)
+    result = run_command(client.assets, "get_asset_info", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -313,7 +311,7 @@ def get_asset_metadata(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "get_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets, "get_asset_metadata", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -333,9 +331,7 @@ def get_asset_metadata_by_key(
     kwargs["id"] = id
     kwargs["key"] = key
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.assets, "get_asset_metadata_by_key", ctx, **kwargs
-    )
+    result = run_command(client.assets, "get_asset_metadata_by_key", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -351,7 +347,7 @@ def get_asset_ocr(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "get_asset_ocr", ctx, **kwargs)
+    result = run_command(client.assets, "get_asset_ocr", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -380,7 +376,7 @@ def get_asset_statistics(
     if visibility is not None:
         kwargs["visibility"] = visibility
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "get_asset_statistics", ctx, **kwargs)
+    result = run_command(client.assets, "get_asset_statistics", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -399,7 +395,7 @@ def get_random(
     if count is not None:
         kwargs["count"] = count
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "get_random", ctx, **kwargs)
+    result = run_command(client.assets, "get_random", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -421,7 +417,7 @@ def play_asset_video(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "play_asset_video", ctx, **kwargs)
+    result = run_command(client.assets, "play_asset_video", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -437,7 +433,7 @@ def remove_asset_edits(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "remove_asset_edits", ctx, **kwargs)
+    result = run_command(client.assets, "remove_asset_edits", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -487,7 +483,7 @@ def replace_asset(
         set_nested(json_data, ["filename"], filename)
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "replace_asset", ctx, **kwargs)
+    result = run_command(client.assets, "replace_asset", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -508,7 +504,7 @@ def run_asset_jobs(
     asset_jobs_dto = AssetJobsDto.model_validate(json_data)
     kwargs["asset_jobs_dto"] = asset_jobs_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "run_asset_jobs", ctx, **kwargs)
+    result = run_command(client.assets, "run_asset_jobs", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -571,7 +567,7 @@ def update_asset(
     update_asset_dto = UpdateAssetDto.model_validate(json_data)
     kwargs["update_asset_dto"] = update_asset_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "update_asset", ctx, **kwargs)
+    result = run_command(client.assets, "update_asset", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -599,7 +595,7 @@ As a JSON string""",
     asset_metadata_upsert_dto = AssetMetadataUpsertDto.model_validate(json_data)
     kwargs["asset_metadata_upsert_dto"] = asset_metadata_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "update_asset_metadata", ctx, **kwargs)
+    result = run_command(client.assets, "update_asset_metadata", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -672,7 +668,7 @@ def update_assets(
     asset_bulk_update_dto = AssetBulkUpdateDto.model_validate(json_data)
     kwargs["asset_bulk_update_dto"] = asset_bulk_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "update_assets", ctx, **kwargs)
+    result = run_command(client.assets, "update_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -702,9 +698,7 @@ As a JSON string""",
     )
     kwargs["asset_metadata_bulk_upsert_dto"] = asset_metadata_bulk_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.assets, "update_bulk_asset_metadata", ctx, **kwargs
-    )
+    result = run_command(client.assets, "update_bulk_asset_metadata", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -791,7 +785,7 @@ As a JSON string""",
         set_nested(json_data, ["visibility"], visibility)
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "upload_asset", ctx, **kwargs)
+    result = run_command(client.assets, "upload_asset", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -823,5 +817,5 @@ def view_asset(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "view_asset", ctx, **kwargs)
+    result = run_command(client.assets, "view_asset", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/assets.py
+++ b/immichpy/cli/commands/assets.py
@@ -41,7 +41,7 @@ As a JSON string""",
     asset_bulk_upload_check_dto = AssetBulkUploadCheckDto.model_validate(json_data)
     kwargs["asset_bulk_upload_check_dto"] = asset_bulk_upload_check_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.check_bulk_upload, ctx, **kwargs)
+    result = run_command(client.assets.check_bulk_upload, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +64,7 @@ def check_existing_assets(
     check_existing_assets_dto = CheckExistingAssetsDto.model_validate(json_data)
     kwargs["check_existing_assets_dto"] = check_existing_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.check_existing_assets, ctx, **kwargs)
+    result = run_command(client.assets.check_existing_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -110,7 +110,7 @@ def copy_asset(
     asset_copy_dto = AssetCopyDto.model_validate(json_data)
     kwargs["asset_copy_dto"] = asset_copy_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.copy_asset, ctx, **kwargs)
+    result = run_command(client.assets.copy_asset, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -128,7 +128,7 @@ def delete_asset_metadata(
     kwargs["id"] = id
     kwargs["key"] = key
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.delete_asset_metadata, ctx, **kwargs)
+    result = run_command(client.assets.delete_asset_metadata, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -152,7 +152,7 @@ def delete_assets(
     asset_bulk_delete_dto = AssetBulkDeleteDto.model_validate(json_data)
     kwargs["asset_bulk_delete_dto"] = asset_bulk_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.delete_assets, ctx, **kwargs)
+    result = run_command(client.assets.delete_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -182,7 +182,7 @@ As a JSON string""",
     )
     kwargs["asset_metadata_bulk_delete_dto"] = asset_metadata_bulk_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.delete_bulk_asset_metadata, ctx, **kwargs)
+    result = run_command(client.assets.delete_bulk_asset_metadata, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -209,7 +209,7 @@ def download_asset(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.download_asset, ctx, **kwargs)
+    result = run_command(client.assets.download_asset, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -237,7 +237,7 @@ As a JSON string""",
     asset_edits_create_dto = AssetEditsCreateDto.model_validate(json_data)
     kwargs["asset_edits_create_dto"] = asset_edits_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.edit_asset, ctx, **kwargs)
+    result = run_command(client.assets.edit_asset, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -255,7 +255,9 @@ def get_all_user_assets_by_device_id(
     kwargs = {}
     kwargs["device_id"] = device_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_all_user_assets_by_device_id, ctx, **kwargs)
+    result = run_command(
+        client.assets.get_all_user_assets_by_device_id, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -271,7 +273,7 @@ def get_asset_edits(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_asset_edits, ctx, **kwargs)
+    result = run_command(client.assets.get_asset_edits, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -293,7 +295,7 @@ def get_asset_info(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_asset_info, ctx, **kwargs)
+    result = run_command(client.assets.get_asset_info, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -309,7 +311,7 @@ def get_asset_metadata(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_asset_metadata, ctx, **kwargs)
+    result = run_command(client.assets.get_asset_metadata, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -329,7 +331,7 @@ def get_asset_metadata_by_key(
     kwargs["id"] = id
     kwargs["key"] = key
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_asset_metadata_by_key, ctx, **kwargs)
+    result = run_command(client.assets.get_asset_metadata_by_key, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -345,7 +347,7 @@ def get_asset_ocr(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_asset_ocr, ctx, **kwargs)
+    result = run_command(client.assets.get_asset_ocr, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -374,7 +376,7 @@ def get_asset_statistics(
     if visibility is not None:
         kwargs["visibility"] = visibility
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_asset_statistics, ctx, **kwargs)
+    result = run_command(client.assets.get_asset_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -393,7 +395,7 @@ def get_random(
     if count is not None:
         kwargs["count"] = count
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.get_random, ctx, **kwargs)
+    result = run_command(client.assets.get_random, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -415,7 +417,7 @@ def play_asset_video(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.play_asset_video, ctx, **kwargs)
+    result = run_command(client.assets.play_asset_video, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -431,7 +433,7 @@ def remove_asset_edits(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.remove_asset_edits, ctx, **kwargs)
+    result = run_command(client.assets.remove_asset_edits, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -481,7 +483,7 @@ def replace_asset(
         set_nested(json_data, ["filename"], filename)
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.replace_asset, ctx, **kwargs)
+    result = run_command(client.assets.replace_asset, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -502,7 +504,7 @@ def run_asset_jobs(
     asset_jobs_dto = AssetJobsDto.model_validate(json_data)
     kwargs["asset_jobs_dto"] = asset_jobs_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.run_asset_jobs, ctx, **kwargs)
+    result = run_command(client.assets.run_asset_jobs, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -565,7 +567,7 @@ def update_asset(
     update_asset_dto = UpdateAssetDto.model_validate(json_data)
     kwargs["update_asset_dto"] = update_asset_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.update_asset, ctx, **kwargs)
+    result = run_command(client.assets.update_asset, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -593,7 +595,7 @@ As a JSON string""",
     asset_metadata_upsert_dto = AssetMetadataUpsertDto.model_validate(json_data)
     kwargs["asset_metadata_upsert_dto"] = asset_metadata_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.update_asset_metadata, ctx, **kwargs)
+    result = run_command(client.assets.update_asset_metadata, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -666,7 +668,7 @@ def update_assets(
     asset_bulk_update_dto = AssetBulkUpdateDto.model_validate(json_data)
     kwargs["asset_bulk_update_dto"] = asset_bulk_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.update_assets, ctx, **kwargs)
+    result = run_command(client.assets.update_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -696,7 +698,7 @@ As a JSON string""",
     )
     kwargs["asset_metadata_bulk_upsert_dto"] = asset_metadata_bulk_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.update_bulk_asset_metadata, ctx, **kwargs)
+    result = run_command(client.assets.update_bulk_asset_metadata, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -783,7 +785,7 @@ As a JSON string""",
         set_nested(json_data, ["visibility"], visibility)
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.upload_asset, ctx, **kwargs)
+    result = run_command(client.assets.upload_asset, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -815,5 +817,5 @@ def view_asset(
     if slug is not None:
         kwargs["slug"] = slug
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.view_asset, ctx, **kwargs)
+    result = run_command(client.assets.view_asset, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/authentication.py
+++ b/immichpy/cli/commands/authentication.py
@@ -52,7 +52,7 @@ Example: password""",
     change_password_dto = ChangePasswordDto.model_validate(json_data)
     kwargs["change_password_dto"] = change_password_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.change_password, ctx, **kwargs)
+    result = run_command(client.auth.change_password, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -93,7 +93,7 @@ Example: 123456""",
     pin_code_change_dto = PinCodeChangeDto.model_validate(json_data)
     kwargs["pin_code_change_dto"] = pin_code_change_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.change_pin_code, ctx, **kwargs)
+    result = run_command(client.auth.change_pin_code, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def finish_o_auth(
     o_auth_callback_dto = OAuthCallbackDto.model_validate(json_data)
     kwargs["o_auth_callback_dto"] = o_auth_callback_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.finish_o_auth, ctx, **kwargs)
+    result = run_command(client.auth.finish_o_auth, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -134,7 +134,7 @@ def get_auth_status(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.get_auth_status, ctx, **kwargs)
+    result = run_command(client.auth.get_auth_status, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -161,7 +161,7 @@ def link_o_auth_account(
     o_auth_callback_dto = OAuthCallbackDto.model_validate(json_data)
     kwargs["o_auth_callback_dto"] = o_auth_callback_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.link_o_auth_account, ctx, **kwargs)
+    result = run_command(client.auth.link_o_auth_account, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -175,7 +175,7 @@ def lock_auth_session(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.lock_auth_session, ctx, **kwargs)
+    result = run_command(client.auth.lock_auth_session, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -208,7 +208,7 @@ Example: password""",
     login_credential_dto = LoginCredentialDto.model_validate(json_data)
     kwargs["login_credential_dto"] = login_credential_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.login, ctx, **kwargs)
+    result = run_command(client.auth.login, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -222,7 +222,7 @@ def logout(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.logout, ctx, **kwargs)
+    result = run_command(client.auth.logout, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -238,7 +238,7 @@ def redirect_o_auth_to_mobile(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.redirect_o_auth_to_mobile, ctx, **kwargs)
+    result = run_command(client.auth.redirect_o_auth_to_mobile, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -271,7 +271,7 @@ Example: 123456""",
     pin_code_reset_dto = PinCodeResetDto.model_validate(json_data)
     kwargs["pin_code_reset_dto"] = pin_code_reset_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.reset_pin_code, ctx, **kwargs)
+    result = run_command(client.auth.reset_pin_code, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -296,7 +296,7 @@ Example: 123456""",
     pin_code_setup_dto = PinCodeSetupDto.model_validate(json_data)
     kwargs["pin_code_setup_dto"] = pin_code_setup_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.setup_pin_code, ctx, **kwargs)
+    result = run_command(client.auth.setup_pin_code, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -337,7 +337,7 @@ Example: password""",
     sign_up_dto = SignUpDto.model_validate(json_data)
     kwargs["sign_up_dto"] = sign_up_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.sign_up_admin, ctx, **kwargs)
+    result = run_command(client.auth.sign_up_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -366,7 +366,7 @@ def start_o_auth(
     o_auth_config_dto = OAuthConfigDto.model_validate(json_data)
     kwargs["o_auth_config_dto"] = o_auth_config_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.start_o_auth, ctx, **kwargs)
+    result = run_command(client.auth.start_o_auth, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -380,7 +380,7 @@ def unlink_o_auth_account(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.unlink_o_auth_account, ctx, **kwargs)
+    result = run_command(client.auth.unlink_o_auth_account, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -413,7 +413,7 @@ Example: 123456""",
     session_unlock_dto = SessionUnlockDto.model_validate(json_data)
     kwargs["session_unlock_dto"] = session_unlock_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.unlock_auth_session, ctx, **kwargs)
+    result = run_command(client.auth.unlock_auth_session, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -427,5 +427,5 @@ def validate_access_token(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth.validate_access_token, ctx, **kwargs)
+    result = run_command(client.auth.validate_access_token, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/authentication.py
+++ b/immichpy/cli/commands/authentication.py
@@ -52,7 +52,7 @@ Example: password""",
     change_password_dto = ChangePasswordDto.model_validate(json_data)
     kwargs["change_password_dto"] = change_password_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "change_password", ctx, **kwargs)
+    result = run_command(client.auth.change_password, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -93,7 +93,7 @@ Example: 123456""",
     pin_code_change_dto = PinCodeChangeDto.model_validate(json_data)
     kwargs["pin_code_change_dto"] = pin_code_change_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "change_pin_code", ctx, **kwargs)
+    result = run_command(client.auth.change_pin_code, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def finish_o_auth(
     o_auth_callback_dto = OAuthCallbackDto.model_validate(json_data)
     kwargs["o_auth_callback_dto"] = o_auth_callback_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "finish_o_auth", ctx, **kwargs)
+    result = run_command(client.auth.finish_o_auth, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -134,7 +134,7 @@ def get_auth_status(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "get_auth_status", ctx, **kwargs)
+    result = run_command(client.auth.get_auth_status, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -161,7 +161,7 @@ def link_o_auth_account(
     o_auth_callback_dto = OAuthCallbackDto.model_validate(json_data)
     kwargs["o_auth_callback_dto"] = o_auth_callback_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "link_o_auth_account", ctx, **kwargs)
+    result = run_command(client.auth.link_o_auth_account, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -175,7 +175,7 @@ def lock_auth_session(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "lock_auth_session", ctx, **kwargs)
+    result = run_command(client.auth.lock_auth_session, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -208,7 +208,7 @@ Example: password""",
     login_credential_dto = LoginCredentialDto.model_validate(json_data)
     kwargs["login_credential_dto"] = login_credential_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "login", ctx, **kwargs)
+    result = run_command(client.auth.login, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -222,7 +222,7 @@ def logout(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "logout", ctx, **kwargs)
+    result = run_command(client.auth.logout, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -238,7 +238,7 @@ def redirect_o_auth_to_mobile(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "redirect_o_auth_to_mobile", ctx, **kwargs)
+    result = run_command(client.auth.redirect_o_auth_to_mobile, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -271,7 +271,7 @@ Example: 123456""",
     pin_code_reset_dto = PinCodeResetDto.model_validate(json_data)
     kwargs["pin_code_reset_dto"] = pin_code_reset_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "reset_pin_code", ctx, **kwargs)
+    result = run_command(client.auth.reset_pin_code, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -296,7 +296,7 @@ Example: 123456""",
     pin_code_setup_dto = PinCodeSetupDto.model_validate(json_data)
     kwargs["pin_code_setup_dto"] = pin_code_setup_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "setup_pin_code", ctx, **kwargs)
+    result = run_command(client.auth.setup_pin_code, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -337,7 +337,7 @@ Example: password""",
     sign_up_dto = SignUpDto.model_validate(json_data)
     kwargs["sign_up_dto"] = sign_up_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "sign_up_admin", ctx, **kwargs)
+    result = run_command(client.auth.sign_up_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -366,7 +366,7 @@ def start_o_auth(
     o_auth_config_dto = OAuthConfigDto.model_validate(json_data)
     kwargs["o_auth_config_dto"] = o_auth_config_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "start_o_auth", ctx, **kwargs)
+    result = run_command(client.auth.start_o_auth, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -380,7 +380,7 @@ def unlink_o_auth_account(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "unlink_o_auth_account", ctx, **kwargs)
+    result = run_command(client.auth.unlink_o_auth_account, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -413,7 +413,7 @@ Example: 123456""",
     session_unlock_dto = SessionUnlockDto.model_validate(json_data)
     kwargs["session_unlock_dto"] = session_unlock_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "unlock_auth_session", ctx, **kwargs)
+    result = run_command(client.auth.unlock_auth_session, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -427,5 +427,5 @@ def validate_access_token(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.auth, "validate_access_token", ctx, **kwargs)
+    result = run_command(client.auth.validate_access_token, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/authentication.py
+++ b/immichpy/cli/commands/authentication.py
@@ -52,7 +52,7 @@ Example: password""",
     change_password_dto = ChangePasswordDto.model_validate(json_data)
     kwargs["change_password_dto"] = change_password_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "change_password", ctx, **kwargs)
+    result = run_command(client.auth, "change_password", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -93,7 +93,7 @@ Example: 123456""",
     pin_code_change_dto = PinCodeChangeDto.model_validate(json_data)
     kwargs["pin_code_change_dto"] = pin_code_change_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "change_pin_code", ctx, **kwargs)
+    result = run_command(client.auth, "change_pin_code", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def finish_o_auth(
     o_auth_callback_dto = OAuthCallbackDto.model_validate(json_data)
     kwargs["o_auth_callback_dto"] = o_auth_callback_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "finish_o_auth", ctx, **kwargs)
+    result = run_command(client.auth, "finish_o_auth", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -134,7 +134,7 @@ def get_auth_status(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "get_auth_status", ctx, **kwargs)
+    result = run_command(client.auth, "get_auth_status", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -161,7 +161,7 @@ def link_o_auth_account(
     o_auth_callback_dto = OAuthCallbackDto.model_validate(json_data)
     kwargs["o_auth_callback_dto"] = o_auth_callback_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "link_o_auth_account", ctx, **kwargs)
+    result = run_command(client.auth, "link_o_auth_account", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -175,7 +175,7 @@ def lock_auth_session(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "lock_auth_session", ctx, **kwargs)
+    result = run_command(client.auth, "lock_auth_session", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -208,7 +208,7 @@ Example: password""",
     login_credential_dto = LoginCredentialDto.model_validate(json_data)
     kwargs["login_credential_dto"] = login_credential_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "login", ctx, **kwargs)
+    result = run_command(client.auth, "login", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -222,7 +222,7 @@ def logout(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "logout", ctx, **kwargs)
+    result = run_command(client.auth, "logout", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -238,9 +238,7 @@ def redirect_o_auth_to_mobile(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.auth, "redirect_o_auth_to_mobile", ctx, **kwargs
-    )
+    result = run_command(client.auth, "redirect_o_auth_to_mobile", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -273,7 +271,7 @@ Example: 123456""",
     pin_code_reset_dto = PinCodeResetDto.model_validate(json_data)
     kwargs["pin_code_reset_dto"] = pin_code_reset_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "reset_pin_code", ctx, **kwargs)
+    result = run_command(client.auth, "reset_pin_code", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -298,7 +296,7 @@ Example: 123456""",
     pin_code_setup_dto = PinCodeSetupDto.model_validate(json_data)
     kwargs["pin_code_setup_dto"] = pin_code_setup_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "setup_pin_code", ctx, **kwargs)
+    result = run_command(client.auth, "setup_pin_code", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -339,7 +337,7 @@ Example: password""",
     sign_up_dto = SignUpDto.model_validate(json_data)
     kwargs["sign_up_dto"] = sign_up_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "sign_up_admin", ctx, **kwargs)
+    result = run_command(client.auth, "sign_up_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -368,7 +366,7 @@ def start_o_auth(
     o_auth_config_dto = OAuthConfigDto.model_validate(json_data)
     kwargs["o_auth_config_dto"] = o_auth_config_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "start_o_auth", ctx, **kwargs)
+    result = run_command(client.auth, "start_o_auth", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -382,7 +380,7 @@ def unlink_o_auth_account(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "unlink_o_auth_account", ctx, **kwargs)
+    result = run_command(client.auth, "unlink_o_auth_account", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -415,7 +413,7 @@ Example: 123456""",
     session_unlock_dto = SessionUnlockDto.model_validate(json_data)
     kwargs["session_unlock_dto"] = session_unlock_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "unlock_auth_session", ctx, **kwargs)
+    result = run_command(client.auth, "unlock_auth_session", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -429,5 +427,5 @@ def validate_access_token(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.auth, "validate_access_token", ctx, **kwargs)
+    result = run_command(client.auth, "validate_access_token", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/authentication_admin.py
+++ b/immichpy/cli/commands/authentication_admin.py
@@ -29,6 +29,6 @@ def unlink_all_o_auth_accounts_admin(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.auth_admin, "unlink_all_o_auth_accounts_admin", ctx, **kwargs
+        client.auth_admin, "unlink_all_o_auth_accounts_admin", ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/authentication_admin.py
+++ b/immichpy/cli/commands/authentication_admin.py
@@ -29,6 +29,6 @@ def unlink_all_o_auth_accounts_admin(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.auth_admin, "unlink_all_o_auth_accounts_admin", ctx, **kwargs
+        client.auth_admin.unlink_all_o_auth_accounts_admin, ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/authentication_admin.py
+++ b/immichpy/cli/commands/authentication_admin.py
@@ -29,6 +29,6 @@ def unlink_all_o_auth_accounts_admin(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.auth_admin.unlink_all_o_auth_accounts_admin, ctx, **kwargs
+        client.auth_admin.unlink_all_o_auth_accounts_admin, ctx=ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/database_backups_admin.py
+++ b/immichpy/cli/commands/database_backups_admin.py
@@ -32,9 +32,7 @@ def delete_database_backup(
     database_backup_delete_dto = DatabaseBackupDeleteDto.model_validate(json_data)
     kwargs["database_backup_delete_dto"] = database_backup_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.backups, "delete_database_backup", ctx, **kwargs
-    )
+    result = run_command(client.backups, "delete_database_backup", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -52,9 +50,7 @@ def download_database_backup(
     kwargs = {}
     kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.backups, "download_database_backup", ctx, **kwargs
-    )
+    result = run_command(client.backups, "download_database_backup", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +64,7 @@ def list_database_backups(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.backups, "list_database_backups", ctx, **kwargs)
+    result = run_command(client.backups, "list_database_backups", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,9 +80,7 @@ def start_database_restore_flow(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.backups, "start_database_restore_flow", ctx, **kwargs
-    )
+    result = run_command(client.backups, "start_database_restore_flow", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -105,7 +99,5 @@ def upload_database_backup(
         set_nested(json_data, ["file"], (file.name, file.read_bytes()))
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.backups, "upload_database_backup", ctx, **kwargs
-    )
+    result = run_command(client.backups, "upload_database_backup", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/database_backups_admin.py
+++ b/immichpy/cli/commands/database_backups_admin.py
@@ -32,7 +32,7 @@ def delete_database_backup(
     database_backup_delete_dto = DatabaseBackupDeleteDto.model_validate(json_data)
     kwargs["database_backup_delete_dto"] = database_backup_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups, "delete_database_backup", ctx, **kwargs)
+    result = run_command(client.backups.delete_database_backup, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -50,7 +50,7 @@ def download_database_backup(
     kwargs = {}
     kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups, "download_database_backup", ctx, **kwargs)
+    result = run_command(client.backups.download_database_backup, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +64,7 @@ def list_database_backups(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups, "list_database_backups", ctx, **kwargs)
+    result = run_command(client.backups.list_database_backups, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -80,7 +80,7 @@ def start_database_restore_flow(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups, "start_database_restore_flow", ctx, **kwargs)
+    result = run_command(client.backups.start_database_restore_flow, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -99,5 +99,5 @@ def upload_database_backup(
         set_nested(json_data, ["file"], (file.name, file.read_bytes()))
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups, "upload_database_backup", ctx, **kwargs)
+    result = run_command(client.backups.upload_database_backup, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/database_backups_admin.py
+++ b/immichpy/cli/commands/database_backups_admin.py
@@ -32,7 +32,7 @@ def delete_database_backup(
     database_backup_delete_dto = DatabaseBackupDeleteDto.model_validate(json_data)
     kwargs["database_backup_delete_dto"] = database_backup_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups.delete_database_backup, ctx, **kwargs)
+    result = run_command(client.backups.delete_database_backup, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -50,7 +50,7 @@ def download_database_backup(
     kwargs = {}
     kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups.download_database_backup, ctx, **kwargs)
+    result = run_command(client.backups.download_database_backup, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +64,7 @@ def list_database_backups(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups.list_database_backups, ctx, **kwargs)
+    result = run_command(client.backups.list_database_backups, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -80,7 +80,7 @@ def start_database_restore_flow(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups.start_database_restore_flow, ctx, **kwargs)
+    result = run_command(client.backups.start_database_restore_flow, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -99,5 +99,5 @@ def upload_database_backup(
         set_nested(json_data, ["file"], (file.name, file.read_bytes()))
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.backups.upload_database_backup, ctx, **kwargs)
+    result = run_command(client.backups.upload_database_backup, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/download.py
+++ b/immichpy/cli/commands/download.py
@@ -42,7 +42,7 @@ def download_archive(
     download_archive_dto = DownloadArchiveDto.model_validate(json_data)
     kwargs["download_archive_dto"] = download_archive_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.download.download_archive, ctx, **kwargs)
+    result = run_command(client.download.download_archive, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,5 +85,5 @@ def get_download_info(
     download_info_dto = DownloadInfoDto.model_validate(json_data)
     kwargs["download_info_dto"] = download_info_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.download.get_download_info, ctx, **kwargs)
+    result = run_command(client.download.get_download_info, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/download.py
+++ b/immichpy/cli/commands/download.py
@@ -42,7 +42,7 @@ def download_archive(
     download_archive_dto = DownloadArchiveDto.model_validate(json_data)
     kwargs["download_archive_dto"] = download_archive_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.download, "download_archive", ctx, **kwargs)
+    result = run_command(client.download.download_archive, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,5 +85,5 @@ def get_download_info(
     download_info_dto = DownloadInfoDto.model_validate(json_data)
     kwargs["download_info_dto"] = download_info_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.download, "get_download_info", ctx, **kwargs)
+    result = run_command(client.download.get_download_info, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/download.py
+++ b/immichpy/cli/commands/download.py
@@ -42,7 +42,7 @@ def download_archive(
     download_archive_dto = DownloadArchiveDto.model_validate(json_data)
     kwargs["download_archive_dto"] = download_archive_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.download, "download_archive", ctx, **kwargs)
+    result = run_command(client.download, "download_archive", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,5 +85,5 @@ def get_download_info(
     download_info_dto = DownloadInfoDto.model_validate(json_data)
     kwargs["download_info_dto"] = download_info_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.download, "get_download_info", ctx, **kwargs)
+    result = run_command(client.download, "get_download_info", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/duplicates.py
+++ b/immichpy/cli/commands/duplicates.py
@@ -29,7 +29,7 @@ def delete_duplicate(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.duplicates, "delete_duplicate", ctx, **kwargs)
+    result = run_command(client.duplicates, "delete_duplicate", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -48,7 +48,7 @@ def delete_duplicates(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.duplicates, "delete_duplicates", ctx, **kwargs)
+    result = run_command(client.duplicates, "delete_duplicates", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -62,9 +62,7 @@ def get_asset_duplicates(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.duplicates, "get_asset_duplicates", ctx, **kwargs
-    )
+    result = run_command(client.duplicates, "get_asset_duplicates", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -90,5 +88,5 @@ As a JSON string""",
     duplicate_resolve_dto = DuplicateResolveDto.model_validate(json_data)
     kwargs["duplicate_resolve_dto"] = duplicate_resolve_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.duplicates, "resolve_duplicates", ctx, **kwargs)
+    result = run_command(client.duplicates, "resolve_duplicates", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/duplicates.py
+++ b/immichpy/cli/commands/duplicates.py
@@ -29,7 +29,7 @@ def delete_duplicate(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates.delete_duplicate, ctx, **kwargs)
+    result = run_command(client.duplicates.delete_duplicate, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -48,7 +48,7 @@ def delete_duplicates(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates.delete_duplicates, ctx, **kwargs)
+    result = run_command(client.duplicates.delete_duplicates, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -62,7 +62,7 @@ def get_asset_duplicates(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates.get_asset_duplicates, ctx, **kwargs)
+    result = run_command(client.duplicates.get_asset_duplicates, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,5 +88,5 @@ As a JSON string""",
     duplicate_resolve_dto = DuplicateResolveDto.model_validate(json_data)
     kwargs["duplicate_resolve_dto"] = duplicate_resolve_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates.resolve_duplicates, ctx, **kwargs)
+    result = run_command(client.duplicates.resolve_duplicates, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/duplicates.py
+++ b/immichpy/cli/commands/duplicates.py
@@ -29,7 +29,7 @@ def delete_duplicate(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates, "delete_duplicate", ctx, **kwargs)
+    result = run_command(client.duplicates.delete_duplicate, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -48,7 +48,7 @@ def delete_duplicates(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates, "delete_duplicates", ctx, **kwargs)
+    result = run_command(client.duplicates.delete_duplicates, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -62,7 +62,7 @@ def get_asset_duplicates(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates, "get_asset_duplicates", ctx, **kwargs)
+    result = run_command(client.duplicates.get_asset_duplicates, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,5 +88,5 @@ As a JSON string""",
     duplicate_resolve_dto = DuplicateResolveDto.model_validate(json_data)
     kwargs["duplicate_resolve_dto"] = duplicate_resolve_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.duplicates, "resolve_duplicates", ctx, **kwargs)
+    result = run_command(client.duplicates.resolve_duplicates, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/faces.py
+++ b/immichpy/cli/commands/faces.py
@@ -49,7 +49,7 @@ def create_face(
     asset_face_create_dto = AssetFaceCreateDto.model_validate(json_data)
     kwargs["asset_face_create_dto"] = asset_face_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces.create_face, ctx, **kwargs)
+    result = run_command(client.faces.create_face, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -72,7 +72,7 @@ def delete_face(
     asset_face_delete_dto = AssetFaceDeleteDto.model_validate(json_data)
     kwargs["asset_face_delete_dto"] = asset_face_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces.delete_face, ctx, **kwargs)
+    result = run_command(client.faces.delete_face, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,7 +88,7 @@ def get_faces(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces.get_faces, ctx, **kwargs)
+    result = run_command(client.faces.get_faces, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -109,5 +109,5 @@ def reassign_faces_by_id(
     face_dto = FaceDto.model_validate(json_data)
     kwargs["face_dto"] = face_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces.reassign_faces_by_id, ctx, **kwargs)
+    result = run_command(client.faces.reassign_faces_by_id, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/faces.py
+++ b/immichpy/cli/commands/faces.py
@@ -49,7 +49,7 @@ def create_face(
     asset_face_create_dto = AssetFaceCreateDto.model_validate(json_data)
     kwargs["asset_face_create_dto"] = asset_face_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces, "create_face", ctx, **kwargs)
+    result = run_command(client.faces.create_face, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -72,7 +72,7 @@ def delete_face(
     asset_face_delete_dto = AssetFaceDeleteDto.model_validate(json_data)
     kwargs["asset_face_delete_dto"] = asset_face_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces, "delete_face", ctx, **kwargs)
+    result = run_command(client.faces.delete_face, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,7 +88,7 @@ def get_faces(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces, "get_faces", ctx, **kwargs)
+    result = run_command(client.faces.get_faces, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -109,5 +109,5 @@ def reassign_faces_by_id(
     face_dto = FaceDto.model_validate(json_data)
     kwargs["face_dto"] = face_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.faces, "reassign_faces_by_id", ctx, **kwargs)
+    result = run_command(client.faces.reassign_faces_by_id, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/faces.py
+++ b/immichpy/cli/commands/faces.py
@@ -49,7 +49,7 @@ def create_face(
     asset_face_create_dto = AssetFaceCreateDto.model_validate(json_data)
     kwargs["asset_face_create_dto"] = asset_face_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.faces, "create_face", ctx, **kwargs)
+    result = run_command(client.faces, "create_face", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -72,7 +72,7 @@ def delete_face(
     asset_face_delete_dto = AssetFaceDeleteDto.model_validate(json_data)
     kwargs["asset_face_delete_dto"] = asset_face_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.faces, "delete_face", ctx, **kwargs)
+    result = run_command(client.faces, "delete_face", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,7 +88,7 @@ def get_faces(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.faces, "get_faces", ctx, **kwargs)
+    result = run_command(client.faces, "get_faces", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -109,5 +109,5 @@ def reassign_faces_by_id(
     face_dto = FaceDto.model_validate(json_data)
     kwargs["face_dto"] = face_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.faces, "reassign_faces_by_id", ctx, **kwargs)
+    result = run_command(client.faces, "reassign_faces_by_id", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/jobs.py
+++ b/immichpy/cli/commands/jobs.py
@@ -31,7 +31,7 @@ def create_job(
     job_create_dto = JobCreateDto.model_validate(json_data)
     kwargs["job_create_dto"] = job_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.jobs, "create_job", ctx, **kwargs)
+    result = run_command(client.jobs, "create_job", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -45,7 +45,7 @@ def get_queues_legacy(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.jobs, "get_queues_legacy", ctx, **kwargs)
+    result = run_command(client.jobs, "get_queues_legacy", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -73,5 +73,5 @@ def run_queue_command_legacy(
     queue_command_dto = QueueCommandDto.model_validate(json_data)
     kwargs["queue_command_dto"] = queue_command_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.jobs, "run_queue_command_legacy", ctx, **kwargs)
+    result = run_command(client.jobs, "run_queue_command_legacy", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/jobs.py
+++ b/immichpy/cli/commands/jobs.py
@@ -31,7 +31,7 @@ def create_job(
     job_create_dto = JobCreateDto.model_validate(json_data)
     kwargs["job_create_dto"] = job_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.jobs.create_job, ctx, **kwargs)
+    result = run_command(client.jobs.create_job, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -45,7 +45,7 @@ def get_queues_legacy(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.jobs.get_queues_legacy, ctx, **kwargs)
+    result = run_command(client.jobs.get_queues_legacy, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -73,5 +73,5 @@ def run_queue_command_legacy(
     queue_command_dto = QueueCommandDto.model_validate(json_data)
     kwargs["queue_command_dto"] = queue_command_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.jobs.run_queue_command_legacy, ctx, **kwargs)
+    result = run_command(client.jobs.run_queue_command_legacy, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/jobs.py
+++ b/immichpy/cli/commands/jobs.py
@@ -31,7 +31,7 @@ def create_job(
     job_create_dto = JobCreateDto.model_validate(json_data)
     kwargs["job_create_dto"] = job_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.jobs, "create_job", ctx, **kwargs)
+    result = run_command(client.jobs.create_job, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -45,7 +45,7 @@ def get_queues_legacy(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.jobs, "get_queues_legacy", ctx, **kwargs)
+    result = run_command(client.jobs.get_queues_legacy, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -73,5 +73,5 @@ def run_queue_command_legacy(
     queue_command_dto = QueueCommandDto.model_validate(json_data)
     kwargs["queue_command_dto"] = queue_command_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.jobs, "run_queue_command_legacy", ctx, **kwargs)
+    result = run_command(client.jobs.run_queue_command_legacy, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/libraries.py
+++ b/immichpy/cli/commands/libraries.py
@@ -44,7 +44,7 @@ def create_library(
     create_library_dto = CreateLibraryDto.model_validate(json_data)
     kwargs["create_library_dto"] = create_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "create_library", ctx, **kwargs)
+    result = run_command(client.libraries.create_library, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -60,7 +60,7 @@ def delete_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "delete_library", ctx, **kwargs)
+    result = run_command(client.libraries.delete_library, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -74,7 +74,7 @@ def get_all_libraries(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "get_all_libraries", ctx, **kwargs)
+    result = run_command(client.libraries.get_all_libraries, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -90,7 +90,7 @@ def get_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "get_library", ctx, **kwargs)
+    result = run_command(client.libraries.get_library, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -106,7 +106,7 @@ def get_library_statistics(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "get_library_statistics", ctx, **kwargs)
+    result = run_command(client.libraries.get_library_statistics, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -122,7 +122,7 @@ def scan_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "scan_library", ctx, **kwargs)
+    result = run_command(client.libraries.scan_library, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,7 +154,7 @@ def update_library(
     update_library_dto = UpdateLibraryDto.model_validate(json_data)
     kwargs["update_library_dto"] = update_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "update_library", ctx, **kwargs)
+    result = run_command(client.libraries.update_library, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -183,5 +183,5 @@ def validate(
     validate_library_dto = ValidateLibraryDto.model_validate(json_data)
     kwargs["validate_library_dto"] = validate_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries, "validate", ctx, **kwargs)
+    result = run_command(client.libraries.validate, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/libraries.py
+++ b/immichpy/cli/commands/libraries.py
@@ -44,7 +44,7 @@ def create_library(
     create_library_dto = CreateLibraryDto.model_validate(json_data)
     kwargs["create_library_dto"] = create_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.create_library, ctx, **kwargs)
+    result = run_command(client.libraries.create_library, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -60,7 +60,7 @@ def delete_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.delete_library, ctx, **kwargs)
+    result = run_command(client.libraries.delete_library, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -74,7 +74,7 @@ def get_all_libraries(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.get_all_libraries, ctx, **kwargs)
+    result = run_command(client.libraries.get_all_libraries, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -90,7 +90,7 @@ def get_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.get_library, ctx, **kwargs)
+    result = run_command(client.libraries.get_library, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -106,7 +106,7 @@ def get_library_statistics(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.get_library_statistics, ctx, **kwargs)
+    result = run_command(client.libraries.get_library_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -122,7 +122,7 @@ def scan_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.scan_library, ctx, **kwargs)
+    result = run_command(client.libraries.scan_library, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,7 +154,7 @@ def update_library(
     update_library_dto = UpdateLibraryDto.model_validate(json_data)
     kwargs["update_library_dto"] = update_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.update_library, ctx, **kwargs)
+    result = run_command(client.libraries.update_library, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -183,5 +183,5 @@ def validate(
     validate_library_dto = ValidateLibraryDto.model_validate(json_data)
     kwargs["validate_library_dto"] = validate_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.libraries.validate, ctx, **kwargs)
+    result = run_command(client.libraries.validate, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/libraries.py
+++ b/immichpy/cli/commands/libraries.py
@@ -44,7 +44,7 @@ def create_library(
     create_library_dto = CreateLibraryDto.model_validate(json_data)
     kwargs["create_library_dto"] = create_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.libraries, "create_library", ctx, **kwargs)
+    result = run_command(client.libraries, "create_library", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -60,7 +60,7 @@ def delete_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.libraries, "delete_library", ctx, **kwargs)
+    result = run_command(client.libraries, "delete_library", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -74,7 +74,7 @@ def get_all_libraries(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.libraries, "get_all_libraries", ctx, **kwargs)
+    result = run_command(client.libraries, "get_all_libraries", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -90,7 +90,7 @@ def get_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.libraries, "get_library", ctx, **kwargs)
+    result = run_command(client.libraries, "get_library", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -106,9 +106,7 @@ def get_library_statistics(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.libraries, "get_library_statistics", ctx, **kwargs
-    )
+    result = run_command(client.libraries, "get_library_statistics", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -124,7 +122,7 @@ def scan_library(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.libraries, "scan_library", ctx, **kwargs)
+    result = run_command(client.libraries, "scan_library", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -156,7 +154,7 @@ def update_library(
     update_library_dto = UpdateLibraryDto.model_validate(json_data)
     kwargs["update_library_dto"] = update_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.libraries, "update_library", ctx, **kwargs)
+    result = run_command(client.libraries, "update_library", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -185,5 +183,5 @@ def validate(
     validate_library_dto = ValidateLibraryDto.model_validate(json_data)
     kwargs["validate_library_dto"] = validate_library_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.libraries, "validate", ctx, **kwargs)
+    result = run_command(client.libraries, "validate", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/maintenance_admin.py
+++ b/immichpy/cli/commands/maintenance_admin.py
@@ -26,7 +26,9 @@ def detect_prior_install(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.maintenance_admin.detect_prior_install, ctx, **kwargs)
+    result = run_command(
+        client.maintenance_admin.detect_prior_install, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -40,7 +42,9 @@ def get_maintenance_status(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.maintenance_admin.get_maintenance_status, ctx, **kwargs)
+    result = run_command(
+        client.maintenance_admin.get_maintenance_status, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -60,7 +64,7 @@ def maintenance_login(
     maintenance_login_dto = MaintenanceLoginDto.model_validate(json_data)
     kwargs["maintenance_login_dto"] = maintenance_login_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.maintenance_admin.maintenance_login, ctx, **kwargs)
+    result = run_command(client.maintenance_admin.maintenance_login, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,5 +88,7 @@ def set_maintenance_mode(
     set_maintenance_mode_dto = SetMaintenanceModeDto.model_validate(json_data)
     kwargs["set_maintenance_mode_dto"] = set_maintenance_mode_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.maintenance_admin.set_maintenance_mode, ctx, **kwargs)
+    result = run_command(
+        client.maintenance_admin.set_maintenance_mode, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)

--- a/immichpy/cli/commands/maintenance_admin.py
+++ b/immichpy/cli/commands/maintenance_admin.py
@@ -27,7 +27,7 @@ def detect_prior_install(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.maintenance_admin, "detect_prior_install", ctx, **kwargs
+        client.maintenance_admin, "detect_prior_install", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -43,7 +43,7 @@ def get_maintenance_status(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.maintenance_admin, "get_maintenance_status", ctx, **kwargs
+        client.maintenance_admin, "get_maintenance_status", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -64,9 +64,7 @@ def maintenance_login(
     maintenance_login_dto = MaintenanceLoginDto.model_validate(json_data)
     kwargs["maintenance_login_dto"] = maintenance_login_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.maintenance_admin, "maintenance_login", ctx, **kwargs
-    )
+    result = run_command(client.maintenance_admin, "maintenance_login", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -91,6 +89,6 @@ def set_maintenance_mode(
     kwargs["set_maintenance_mode_dto"] = set_maintenance_mode_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.maintenance_admin, "set_maintenance_mode", ctx, **kwargs
+        client.maintenance_admin, "set_maintenance_mode", ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/maintenance_admin.py
+++ b/immichpy/cli/commands/maintenance_admin.py
@@ -26,9 +26,7 @@ def detect_prior_install(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.maintenance_admin, "detect_prior_install", ctx, **kwargs
-    )
+    result = run_command(client.maintenance_admin.detect_prior_install, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -42,9 +40,7 @@ def get_maintenance_status(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.maintenance_admin, "get_maintenance_status", ctx, **kwargs
-    )
+    result = run_command(client.maintenance_admin.get_maintenance_status, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +60,7 @@ def maintenance_login(
     maintenance_login_dto = MaintenanceLoginDto.model_validate(json_data)
     kwargs["maintenance_login_dto"] = maintenance_login_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.maintenance_admin, "maintenance_login", ctx, **kwargs)
+    result = run_command(client.maintenance_admin.maintenance_login, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,7 +84,5 @@ def set_maintenance_mode(
     set_maintenance_mode_dto = SetMaintenanceModeDto.model_validate(json_data)
     kwargs["set_maintenance_mode_dto"] = set_maintenance_mode_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.maintenance_admin, "set_maintenance_mode", ctx, **kwargs
-    )
+    result = run_command(client.maintenance_admin.set_maintenance_mode, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/map.py
+++ b/immichpy/cli/commands/map.py
@@ -57,7 +57,7 @@ def get_map_markers(
     if with_shared_albums is not None:
         kwargs["with_shared_albums"] = with_shared_albums.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.map, "get_map_markers", ctx, **kwargs)
+    result = run_command(client.map, "get_map_markers", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,5 +75,5 @@ def reverse_geocode(
     kwargs["lat"] = lat
     kwargs["lon"] = lon
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.map, "reverse_geocode", ctx, **kwargs)
+    result = run_command(client.map, "reverse_geocode", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/map.py
+++ b/immichpy/cli/commands/map.py
@@ -57,7 +57,7 @@ def get_map_markers(
     if with_shared_albums is not None:
         kwargs["with_shared_albums"] = with_shared_albums.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.map.get_map_markers, ctx, **kwargs)
+    result = run_command(client.map.get_map_markers, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,5 +75,5 @@ def reverse_geocode(
     kwargs["lat"] = lat
     kwargs["lon"] = lon
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.map.reverse_geocode, ctx, **kwargs)
+    result = run_command(client.map.reverse_geocode, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/map.py
+++ b/immichpy/cli/commands/map.py
@@ -57,7 +57,7 @@ def get_map_markers(
     if with_shared_albums is not None:
         kwargs["with_shared_albums"] = with_shared_albums.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.map, "get_map_markers", ctx, **kwargs)
+    result = run_command(client.map.get_map_markers, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,5 +75,5 @@ def reverse_geocode(
     kwargs["lat"] = lat
     kwargs["lon"] = lon
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.map, "reverse_geocode", ctx, **kwargs)
+    result = run_command(client.map.reverse_geocode, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/memories.py
+++ b/immichpy/cli/commands/memories.py
@@ -34,7 +34,7 @@ def add_memory_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "add_memory_assets", ctx, **kwargs)
+    result = run_command(client.memories.add_memory_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,7 +84,7 @@ def create_memory(
     memory_create_dto = MemoryCreateDto.model_validate(json_data)
     kwargs["memory_create_dto"] = memory_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "create_memory", ctx, **kwargs)
+    result = run_command(client.memories.create_memory, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -100,7 +100,7 @@ def delete_memory(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "delete_memory", ctx, **kwargs)
+    result = run_command(client.memories.delete_memory, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -116,7 +116,7 @@ def get_memory(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "get_memory", ctx, **kwargs)
+    result = run_command(client.memories.get_memory, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -156,7 +156,7 @@ def memories_statistics(
     if type is not None:
         kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "memories_statistics", ctx, **kwargs)
+    result = run_command(client.memories.memories_statistics, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def remove_memory_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "remove_memory_assets", ctx, **kwargs)
+    result = run_command(client.memories.remove_memory_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -217,7 +217,7 @@ def search_memories(
     if type is not None:
         kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "search_memories", ctx, **kwargs)
+    result = run_command(client.memories.search_memories, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -251,5 +251,5 @@ def update_memory(
     memory_update_dto = MemoryUpdateDto.model_validate(json_data)
     kwargs["memory_update_dto"] = memory_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories, "update_memory", ctx, **kwargs)
+    result = run_command(client.memories.update_memory, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/memories.py
+++ b/immichpy/cli/commands/memories.py
@@ -34,7 +34,7 @@ def add_memory_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.add_memory_assets, ctx, **kwargs)
+    result = run_command(client.memories.add_memory_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,7 +84,7 @@ def create_memory(
     memory_create_dto = MemoryCreateDto.model_validate(json_data)
     kwargs["memory_create_dto"] = memory_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.create_memory, ctx, **kwargs)
+    result = run_command(client.memories.create_memory, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -100,7 +100,7 @@ def delete_memory(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.delete_memory, ctx, **kwargs)
+    result = run_command(client.memories.delete_memory, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -116,7 +116,7 @@ def get_memory(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.get_memory, ctx, **kwargs)
+    result = run_command(client.memories.get_memory, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -156,7 +156,7 @@ def memories_statistics(
     if type is not None:
         kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.memories_statistics, ctx, **kwargs)
+    result = run_command(client.memories.memories_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def remove_memory_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.remove_memory_assets, ctx, **kwargs)
+    result = run_command(client.memories.remove_memory_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -217,7 +217,7 @@ def search_memories(
     if type is not None:
         kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.search_memories, ctx, **kwargs)
+    result = run_command(client.memories.search_memories, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -251,5 +251,5 @@ def update_memory(
     memory_update_dto = MemoryUpdateDto.model_validate(json_data)
     kwargs["memory_update_dto"] = memory_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.memories.update_memory, ctx, **kwargs)
+    result = run_command(client.memories.update_memory, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/memories.py
+++ b/immichpy/cli/commands/memories.py
@@ -34,7 +34,7 @@ def add_memory_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "add_memory_assets", ctx, **kwargs)
+    result = run_command(client.memories, "add_memory_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,7 +84,7 @@ def create_memory(
     memory_create_dto = MemoryCreateDto.model_validate(json_data)
     kwargs["memory_create_dto"] = memory_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "create_memory", ctx, **kwargs)
+    result = run_command(client.memories, "create_memory", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -100,7 +100,7 @@ def delete_memory(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "delete_memory", ctx, **kwargs)
+    result = run_command(client.memories, "delete_memory", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -116,7 +116,7 @@ def get_memory(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "get_memory", ctx, **kwargs)
+    result = run_command(client.memories, "get_memory", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -156,7 +156,7 @@ def memories_statistics(
     if type is not None:
         kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "memories_statistics", ctx, **kwargs)
+    result = run_command(client.memories, "memories_statistics", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def remove_memory_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "remove_memory_assets", ctx, **kwargs)
+    result = run_command(client.memories, "remove_memory_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -217,7 +217,7 @@ def search_memories(
     if type is not None:
         kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "search_memories", ctx, **kwargs)
+    result = run_command(client.memories, "search_memories", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -251,5 +251,5 @@ def update_memory(
     memory_update_dto = MemoryUpdateDto.model_validate(json_data)
     kwargs["memory_update_dto"] = memory_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.memories, "update_memory", ctx, **kwargs)
+    result = run_command(client.memories, "update_memory", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/notifications.py
+++ b/immichpy/cli/commands/notifications.py
@@ -29,9 +29,7 @@ def delete_notification(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.notifications, "delete_notification", ctx, **kwargs
-    )
+    result = run_command(client.notifications, "delete_notification", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -50,9 +48,7 @@ def delete_notifications(
     notification_delete_all_dto = NotificationDeleteAllDto.model_validate(json_data)
     kwargs["notification_delete_all_dto"] = notification_delete_all_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.notifications, "delete_notifications", ctx, **kwargs
-    )
+    result = run_command(client.notifications, "delete_notifications", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,9 +64,7 @@ def get_notification(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.notifications, "get_notification", ctx, **kwargs
-    )
+    result = run_command(client.notifications, "get_notification", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -102,9 +96,7 @@ def get_notifications(
     if unread is not None:
         kwargs["unread"] = unread.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.notifications, "get_notifications", ctx, **kwargs
-    )
+    result = run_command(client.notifications, "get_notifications", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -128,9 +120,7 @@ def update_notification(
     notification_update_dto = NotificationUpdateDto.model_validate(json_data)
     kwargs["notification_update_dto"] = notification_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.notifications, "update_notification", ctx, **kwargs
-    )
+    result = run_command(client.notifications, "update_notification", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,7 +144,5 @@ def update_notifications(
     notification_update_all_dto = NotificationUpdateAllDto.model_validate(json_data)
     kwargs["notification_update_all_dto"] = notification_update_all_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.notifications, "update_notifications", ctx, **kwargs
-    )
+    result = run_command(client.notifications, "update_notifications", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/notifications.py
+++ b/immichpy/cli/commands/notifications.py
@@ -29,7 +29,7 @@ def delete_notification(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications, "delete_notification", ctx, **kwargs)
+    result = run_command(client.notifications.delete_notification, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -48,7 +48,7 @@ def delete_notifications(
     notification_delete_all_dto = NotificationDeleteAllDto.model_validate(json_data)
     kwargs["notification_delete_all_dto"] = notification_delete_all_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications, "delete_notifications", ctx, **kwargs)
+    result = run_command(client.notifications.delete_notifications, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +64,7 @@ def get_notification(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications, "get_notification", ctx, **kwargs)
+    result = run_command(client.notifications.get_notification, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_notifications(
     if unread is not None:
         kwargs["unread"] = unread.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications, "get_notifications", ctx, **kwargs)
+    result = run_command(client.notifications.get_notifications, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def update_notification(
     notification_update_dto = NotificationUpdateDto.model_validate(json_data)
     kwargs["notification_update_dto"] = notification_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications, "update_notification", ctx, **kwargs)
+    result = run_command(client.notifications.update_notification, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -144,5 +144,5 @@ def update_notifications(
     notification_update_all_dto = NotificationUpdateAllDto.model_validate(json_data)
     kwargs["notification_update_all_dto"] = notification_update_all_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications, "update_notifications", ctx, **kwargs)
+    result = run_command(client.notifications.update_notifications, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/notifications.py
+++ b/immichpy/cli/commands/notifications.py
@@ -29,7 +29,7 @@ def delete_notification(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications.delete_notification, ctx, **kwargs)
+    result = run_command(client.notifications.delete_notification, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -48,7 +48,7 @@ def delete_notifications(
     notification_delete_all_dto = NotificationDeleteAllDto.model_validate(json_data)
     kwargs["notification_delete_all_dto"] = notification_delete_all_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications.delete_notifications, ctx, **kwargs)
+    result = run_command(client.notifications.delete_notifications, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -64,7 +64,7 @@ def get_notification(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications.get_notification, ctx, **kwargs)
+    result = run_command(client.notifications.get_notification, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_notifications(
     if unread is not None:
         kwargs["unread"] = unread.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications.get_notifications, ctx, **kwargs)
+    result = run_command(client.notifications.get_notifications, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def update_notification(
     notification_update_dto = NotificationUpdateDto.model_validate(json_data)
     kwargs["notification_update_dto"] = notification_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications.update_notification, ctx, **kwargs)
+    result = run_command(client.notifications.update_notification, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -144,5 +144,5 @@ def update_notifications(
     notification_update_all_dto = NotificationUpdateAllDto.model_validate(json_data)
     kwargs["notification_update_all_dto"] = notification_update_all_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications.update_notifications, ctx, **kwargs)
+    result = run_command(client.notifications.update_notifications, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/notifications_admin.py
+++ b/immichpy/cli/commands/notifications_admin.py
@@ -63,9 +63,7 @@ As a JSON string""",
     notification_create_dto = NotificationCreateDto.model_validate(json_data)
     kwargs["notification_create_dto"] = notification_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.notifications_admin, "create_notification", ctx, **kwargs
-    )
+    result = run_command(client.notifications_admin.create_notification, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -89,7 +87,7 @@ def get_notification_template_admin(
     kwargs["template_dto"] = template_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.notifications_admin, "get_notification_template_admin", ctx, **kwargs
+        client.notifications_admin.get_notification_template_admin, ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -144,6 +142,6 @@ def send_test_email_admin(
     kwargs["system_config_smtp_dto"] = system_config_smtp_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.notifications_admin, "send_test_email_admin", ctx, **kwargs
+        client.notifications_admin.send_test_email_admin, ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/notifications_admin.py
+++ b/immichpy/cli/commands/notifications_admin.py
@@ -63,7 +63,9 @@ As a JSON string""",
     notification_create_dto = NotificationCreateDto.model_validate(json_data)
     kwargs["notification_create_dto"] = notification_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.notifications_admin.create_notification, ctx, **kwargs)
+    result = run_command(
+        client.notifications_admin.create_notification, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -87,7 +89,7 @@ def get_notification_template_admin(
     kwargs["template_dto"] = template_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.notifications_admin.get_notification_template_admin, ctx, **kwargs
+        client.notifications_admin.get_notification_template_admin, ctx=ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -142,6 +144,6 @@ def send_test_email_admin(
     kwargs["system_config_smtp_dto"] = system_config_smtp_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.notifications_admin.send_test_email_admin, ctx, **kwargs
+        client.notifications_admin.send_test_email_admin, ctx=ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/notifications_admin.py
+++ b/immichpy/cli/commands/notifications_admin.py
@@ -64,7 +64,7 @@ As a JSON string""",
     kwargs["notification_create_dto"] = notification_create_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.notifications_admin, "create_notification", ctx, **kwargs
+        client.notifications_admin, "create_notification", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -89,11 +89,7 @@ def get_notification_template_admin(
     kwargs["template_dto"] = template_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client,
-        client.notifications_admin,
-        "get_notification_template_admin",
-        ctx,
-        **kwargs,
+        client.notifications_admin, "get_notification_template_admin", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -148,6 +144,6 @@ def send_test_email_admin(
     kwargs["system_config_smtp_dto"] = system_config_smtp_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.notifications_admin, "send_test_email_admin", ctx, **kwargs
+        client.notifications_admin, "send_test_email_admin", ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/partners.py
+++ b/immichpy/cli/commands/partners.py
@@ -33,7 +33,7 @@ def create_partner(
     partner_create_dto = PartnerCreateDto.model_validate(json_data)
     kwargs["partner_create_dto"] = partner_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners, "create_partner", ctx, **kwargs)
+    result = run_command(client.partners.create_partner, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -51,7 +51,7 @@ def create_partner_deprecated(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners, "create_partner_deprecated", ctx, **kwargs)
+    result = run_command(client.partners.create_partner_deprecated, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -69,7 +69,7 @@ def get_partners(
     kwargs = {}
     kwargs["direction"] = direction
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners, "get_partners", ctx, **kwargs)
+    result = run_command(client.partners.get_partners, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,7 +85,7 @@ def remove_partner(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners, "remove_partner", ctx, **kwargs)
+    result = run_command(client.partners.remove_partner, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -108,5 +108,5 @@ def update_partner(
     partner_update_dto = PartnerUpdateDto.model_validate(json_data)
     kwargs["partner_update_dto"] = partner_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners, "update_partner", ctx, **kwargs)
+    result = run_command(client.partners.update_partner, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/partners.py
+++ b/immichpy/cli/commands/partners.py
@@ -33,7 +33,7 @@ def create_partner(
     partner_create_dto = PartnerCreateDto.model_validate(json_data)
     kwargs["partner_create_dto"] = partner_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners.create_partner, ctx, **kwargs)
+    result = run_command(client.partners.create_partner, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -51,7 +51,7 @@ def create_partner_deprecated(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners.create_partner_deprecated, ctx, **kwargs)
+    result = run_command(client.partners.create_partner_deprecated, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -69,7 +69,7 @@ def get_partners(
     kwargs = {}
     kwargs["direction"] = direction
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners.get_partners, ctx, **kwargs)
+    result = run_command(client.partners.get_partners, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,7 +85,7 @@ def remove_partner(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners.remove_partner, ctx, **kwargs)
+    result = run_command(client.partners.remove_partner, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -108,5 +108,5 @@ def update_partner(
     partner_update_dto = PartnerUpdateDto.model_validate(json_data)
     kwargs["partner_update_dto"] = partner_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.partners.update_partner, ctx, **kwargs)
+    result = run_command(client.partners.update_partner, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/partners.py
+++ b/immichpy/cli/commands/partners.py
@@ -33,7 +33,7 @@ def create_partner(
     partner_create_dto = PartnerCreateDto.model_validate(json_data)
     kwargs["partner_create_dto"] = partner_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.partners, "create_partner", ctx, **kwargs)
+    result = run_command(client.partners, "create_partner", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -51,9 +51,7 @@ def create_partner_deprecated(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.partners, "create_partner_deprecated", ctx, **kwargs
-    )
+    result = run_command(client.partners, "create_partner_deprecated", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -71,7 +69,7 @@ def get_partners(
     kwargs = {}
     kwargs["direction"] = direction
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.partners, "get_partners", ctx, **kwargs)
+    result = run_command(client.partners, "get_partners", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -87,7 +85,7 @@ def remove_partner(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.partners, "remove_partner", ctx, **kwargs)
+    result = run_command(client.partners, "remove_partner", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -110,5 +108,5 @@ def update_partner(
     partner_update_dto = PartnerUpdateDto.model_validate(json_data)
     kwargs["partner_update_dto"] = partner_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.partners, "update_partner", ctx, **kwargs)
+    result = run_command(client.partners, "update_partner", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/people.py
+++ b/immichpy/cli/commands/people.py
@@ -51,7 +51,7 @@ def create_person(
     person_create_dto = PersonCreateDto.model_validate(json_data)
     kwargs["person_create_dto"] = person_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "create_person", ctx, **kwargs)
+    result = run_command(client.people, "create_person", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -70,7 +70,7 @@ def delete_people(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "delete_people", ctx, **kwargs)
+    result = run_command(client.people, "delete_people", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -86,7 +86,7 @@ def delete_person(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "delete_person", ctx, **kwargs)
+    result = run_command(client.people, "delete_person", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -125,7 +125,7 @@ def get_all_people(
     if with_hidden is not None:
         kwargs["with_hidden"] = with_hidden.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "get_all_people", ctx, **kwargs)
+    result = run_command(client.people, "get_all_people", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -141,7 +141,7 @@ def get_person(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "get_person", ctx, **kwargs)
+    result = run_command(client.people, "get_person", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -157,7 +157,7 @@ def get_person_statistics(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "get_person_statistics", ctx, **kwargs)
+    result = run_command(client.people, "get_person_statistics", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -173,7 +173,7 @@ def get_person_thumbnail(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "get_person_thumbnail", ctx, **kwargs)
+    result = run_command(client.people, "get_person_thumbnail", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -194,7 +194,7 @@ def merge_person(
     merge_person_dto = MergePersonDto.model_validate(json_data)
     kwargs["merge_person_dto"] = merge_person_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "merge_person", ctx, **kwargs)
+    result = run_command(client.people, "merge_person", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -222,7 +222,7 @@ As a JSON string""",
     asset_face_update_dto = AssetFaceUpdateDto.model_validate(json_data)
     kwargs["asset_face_update_dto"] = asset_face_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "reassign_faces", ctx, **kwargs)
+    result = run_command(client.people, "reassign_faces", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -248,7 +248,7 @@ As a JSON string""",
     people_update_dto = PeopleUpdateDto.model_validate(json_data)
     kwargs["people_update_dto"] = people_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "update_people", ctx, **kwargs)
+    result = run_command(client.people, "update_people", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -295,5 +295,5 @@ def update_person(
     person_update_dto = PersonUpdateDto.model_validate(json_data)
     kwargs["person_update_dto"] = person_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.people, "update_person", ctx, **kwargs)
+    result = run_command(client.people, "update_person", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/people.py
+++ b/immichpy/cli/commands/people.py
@@ -51,7 +51,7 @@ def create_person(
     person_create_dto = PersonCreateDto.model_validate(json_data)
     kwargs["person_create_dto"] = person_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.create_person, ctx, **kwargs)
+    result = run_command(client.people.create_person, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -70,7 +70,7 @@ def delete_people(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.delete_people, ctx, **kwargs)
+    result = run_command(client.people.delete_people, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -86,7 +86,7 @@ def delete_person(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.delete_person, ctx, **kwargs)
+    result = run_command(client.people.delete_person, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -125,7 +125,7 @@ def get_all_people(
     if with_hidden is not None:
         kwargs["with_hidden"] = with_hidden.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.get_all_people, ctx, **kwargs)
+    result = run_command(client.people.get_all_people, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -141,7 +141,7 @@ def get_person(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.get_person, ctx, **kwargs)
+    result = run_command(client.people.get_person, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -157,7 +157,7 @@ def get_person_statistics(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.get_person_statistics, ctx, **kwargs)
+    result = run_command(client.people.get_person_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -173,7 +173,7 @@ def get_person_thumbnail(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.get_person_thumbnail, ctx, **kwargs)
+    result = run_command(client.people.get_person_thumbnail, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -194,7 +194,7 @@ def merge_person(
     merge_person_dto = MergePersonDto.model_validate(json_data)
     kwargs["merge_person_dto"] = merge_person_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.merge_person, ctx, **kwargs)
+    result = run_command(client.people.merge_person, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -222,7 +222,7 @@ As a JSON string""",
     asset_face_update_dto = AssetFaceUpdateDto.model_validate(json_data)
     kwargs["asset_face_update_dto"] = asset_face_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.reassign_faces, ctx, **kwargs)
+    result = run_command(client.people.reassign_faces, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -248,7 +248,7 @@ As a JSON string""",
     people_update_dto = PeopleUpdateDto.model_validate(json_data)
     kwargs["people_update_dto"] = people_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.update_people, ctx, **kwargs)
+    result = run_command(client.people.update_people, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -295,5 +295,5 @@ def update_person(
     person_update_dto = PersonUpdateDto.model_validate(json_data)
     kwargs["person_update_dto"] = person_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people.update_person, ctx, **kwargs)
+    result = run_command(client.people.update_person, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/people.py
+++ b/immichpy/cli/commands/people.py
@@ -51,7 +51,7 @@ def create_person(
     person_create_dto = PersonCreateDto.model_validate(json_data)
     kwargs["person_create_dto"] = person_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "create_person", ctx, **kwargs)
+    result = run_command(client.people.create_person, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -70,7 +70,7 @@ def delete_people(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "delete_people", ctx, **kwargs)
+    result = run_command(client.people.delete_people, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -86,7 +86,7 @@ def delete_person(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "delete_person", ctx, **kwargs)
+    result = run_command(client.people.delete_person, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -125,7 +125,7 @@ def get_all_people(
     if with_hidden is not None:
         kwargs["with_hidden"] = with_hidden.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "get_all_people", ctx, **kwargs)
+    result = run_command(client.people.get_all_people, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -141,7 +141,7 @@ def get_person(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "get_person", ctx, **kwargs)
+    result = run_command(client.people.get_person, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -157,7 +157,7 @@ def get_person_statistics(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "get_person_statistics", ctx, **kwargs)
+    result = run_command(client.people.get_person_statistics, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -173,7 +173,7 @@ def get_person_thumbnail(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "get_person_thumbnail", ctx, **kwargs)
+    result = run_command(client.people.get_person_thumbnail, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -194,7 +194,7 @@ def merge_person(
     merge_person_dto = MergePersonDto.model_validate(json_data)
     kwargs["merge_person_dto"] = merge_person_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "merge_person", ctx, **kwargs)
+    result = run_command(client.people.merge_person, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -222,7 +222,7 @@ As a JSON string""",
     asset_face_update_dto = AssetFaceUpdateDto.model_validate(json_data)
     kwargs["asset_face_update_dto"] = asset_face_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "reassign_faces", ctx, **kwargs)
+    result = run_command(client.people.reassign_faces, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -248,7 +248,7 @@ As a JSON string""",
     people_update_dto = PeopleUpdateDto.model_validate(json_data)
     kwargs["people_update_dto"] = people_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "update_people", ctx, **kwargs)
+    result = run_command(client.people.update_people, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -295,5 +295,5 @@ def update_person(
     person_update_dto = PersonUpdateDto.model_validate(json_data)
     kwargs["person_update_dto"] = person_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.people, "update_person", ctx, **kwargs)
+    result = run_command(client.people.update_person, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/plugins.py
+++ b/immichpy/cli/commands/plugins.py
@@ -28,7 +28,7 @@ def get_plugin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.plugins, "get_plugin", ctx, **kwargs)
+    result = run_command(client.plugins.get_plugin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -42,7 +42,7 @@ def get_plugin_triggers(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.plugins, "get_plugin_triggers", ctx, **kwargs)
+    result = run_command(client.plugins.get_plugin_triggers, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -56,5 +56,5 @@ def get_plugins(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.plugins, "get_plugins", ctx, **kwargs)
+    result = run_command(client.plugins.get_plugins, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/plugins.py
+++ b/immichpy/cli/commands/plugins.py
@@ -28,7 +28,7 @@ def get_plugin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.plugins.get_plugin, ctx, **kwargs)
+    result = run_command(client.plugins.get_plugin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -42,7 +42,7 @@ def get_plugin_triggers(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.plugins.get_plugin_triggers, ctx, **kwargs)
+    result = run_command(client.plugins.get_plugin_triggers, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -56,5 +56,5 @@ def get_plugins(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.plugins.get_plugins, ctx, **kwargs)
+    result = run_command(client.plugins.get_plugins, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/plugins.py
+++ b/immichpy/cli/commands/plugins.py
@@ -28,7 +28,7 @@ def get_plugin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.plugins, "get_plugin", ctx, **kwargs)
+    result = run_command(client.plugins, "get_plugin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -42,7 +42,7 @@ def get_plugin_triggers(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.plugins, "get_plugin_triggers", ctx, **kwargs)
+    result = run_command(client.plugins, "get_plugin_triggers", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -56,5 +56,5 @@ def get_plugins(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.plugins, "get_plugins", ctx, **kwargs)
+    result = run_command(client.plugins, "get_plugins", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/queues.py
+++ b/immichpy/cli/commands/queues.py
@@ -38,7 +38,7 @@ def empty_queue(
     queue_delete_dto = QueueDeleteDto.model_validate(json_data)
     kwargs["queue_delete_dto"] = queue_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues.empty_queue, ctx, **kwargs)
+    result = run_command(client.queues.empty_queue, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -54,7 +54,7 @@ def get_queue(
     kwargs = {}
     kwargs["name"] = name
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues.get_queue, ctx, **kwargs)
+    result = run_command(client.queues.get_queue, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,7 +75,7 @@ def get_queue_jobs(
     if status is not None:
         kwargs["status"] = status
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues.get_queue_jobs, ctx, **kwargs)
+    result = run_command(client.queues.get_queue_jobs, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -89,7 +89,7 @@ def get_queues(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues.get_queues, ctx, **kwargs)
+    result = run_command(client.queues.get_queues, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -113,5 +113,5 @@ def update_queue(
     queue_update_dto = QueueUpdateDto.model_validate(json_data)
     kwargs["queue_update_dto"] = queue_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues.update_queue, ctx, **kwargs)
+    result = run_command(client.queues.update_queue, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/queues.py
+++ b/immichpy/cli/commands/queues.py
@@ -38,7 +38,7 @@ def empty_queue(
     queue_delete_dto = QueueDeleteDto.model_validate(json_data)
     kwargs["queue_delete_dto"] = queue_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues, "empty_queue", ctx, **kwargs)
+    result = run_command(client.queues.empty_queue, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -54,7 +54,7 @@ def get_queue(
     kwargs = {}
     kwargs["name"] = name
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues, "get_queue", ctx, **kwargs)
+    result = run_command(client.queues.get_queue, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,7 +75,7 @@ def get_queue_jobs(
     if status is not None:
         kwargs["status"] = status
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues, "get_queue_jobs", ctx, **kwargs)
+    result = run_command(client.queues.get_queue_jobs, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -89,7 +89,7 @@ def get_queues(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues, "get_queues", ctx, **kwargs)
+    result = run_command(client.queues.get_queues, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -113,5 +113,5 @@ def update_queue(
     queue_update_dto = QueueUpdateDto.model_validate(json_data)
     kwargs["queue_update_dto"] = queue_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.queues, "update_queue", ctx, **kwargs)
+    result = run_command(client.queues.update_queue, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/queues.py
+++ b/immichpy/cli/commands/queues.py
@@ -38,7 +38,7 @@ def empty_queue(
     queue_delete_dto = QueueDeleteDto.model_validate(json_data)
     kwargs["queue_delete_dto"] = queue_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.queues, "empty_queue", ctx, **kwargs)
+    result = run_command(client.queues, "empty_queue", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -54,7 +54,7 @@ def get_queue(
     kwargs = {}
     kwargs["name"] = name
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.queues, "get_queue", ctx, **kwargs)
+    result = run_command(client.queues, "get_queue", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,7 +75,7 @@ def get_queue_jobs(
     if status is not None:
         kwargs["status"] = status
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.queues, "get_queue_jobs", ctx, **kwargs)
+    result = run_command(client.queues, "get_queue_jobs", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -89,7 +89,7 @@ def get_queues(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.queues, "get_queues", ctx, **kwargs)
+    result = run_command(client.queues, "get_queues", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -113,5 +113,5 @@ def update_queue(
     queue_update_dto = QueueUpdateDto.model_validate(json_data)
     kwargs["queue_update_dto"] = queue_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.queues, "update_queue", ctx, **kwargs)
+    result = run_command(client.queues, "update_queue", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/search.py
+++ b/immichpy/cli/commands/search.py
@@ -27,7 +27,7 @@ def get_assets_by_city(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "get_assets_by_city", ctx, **kwargs)
+    result = run_command(client.search, "get_assets_by_city", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -41,7 +41,7 @@ def get_explore_data(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "get_explore_data", ctx, **kwargs)
+    result = run_command(client.search, "get_explore_data", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,7 +85,7 @@ def get_search_suggestions(
         kwargs["state"] = state
     kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "get_search_suggestions", ctx, **kwargs)
+    result = run_command(client.search, "get_search_suggestions", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -247,9 +247,7 @@ def search_asset_statistics(
     statistics_search_dto = StatisticsSearchDto.model_validate(json_data)
     kwargs["statistics_search_dto"] = statistics_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.search, "search_asset_statistics", ctx, **kwargs
-    )
+    result = run_command(client.search, "search_asset_statistics", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -478,7 +476,7 @@ def search_assets(
     metadata_search_dto = MetadataSearchDto.model_validate(json_data)
     kwargs["metadata_search_dto"] = metadata_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "search_assets", ctx, **kwargs)
+    result = run_command(client.search, "search_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -652,7 +650,7 @@ def search_large_assets(
     if with_exif is not None:
         kwargs["with_exif"] = with_exif.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "search_large_assets", ctx, **kwargs)
+    result = run_command(client.search, "search_large_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -673,7 +671,7 @@ def search_person(
     if with_hidden is not None:
         kwargs["with_hidden"] = with_hidden.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "search_person", ctx, **kwargs)
+    result = run_command(client.search, "search_person", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -689,7 +687,7 @@ def search_places(
     kwargs = {}
     kwargs["name"] = name
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "search_places", ctx, **kwargs)
+    result = run_command(client.search, "search_places", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -869,7 +867,7 @@ def search_random(
     random_search_dto = RandomSearchDto.model_validate(json_data)
     kwargs["random_search_dto"] = random_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "search_random", ctx, **kwargs)
+    result = run_command(client.search, "search_random", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -1057,5 +1055,5 @@ def search_smart(
     smart_search_dto = SmartSearchDto.model_validate(json_data)
     kwargs["smart_search_dto"] = smart_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.search, "search_smart", ctx, **kwargs)
+    result = run_command(client.search, "search_smart", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/search.py
+++ b/immichpy/cli/commands/search.py
@@ -27,7 +27,7 @@ def get_assets_by_city(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.get_assets_by_city, ctx, **kwargs)
+    result = run_command(client.search.get_assets_by_city, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -41,7 +41,7 @@ def get_explore_data(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.get_explore_data, ctx, **kwargs)
+    result = run_command(client.search.get_explore_data, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,7 +85,7 @@ def get_search_suggestions(
         kwargs["state"] = state
     kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.get_search_suggestions, ctx, **kwargs)
+    result = run_command(client.search.get_search_suggestions, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -247,7 +247,7 @@ def search_asset_statistics(
     statistics_search_dto = StatisticsSearchDto.model_validate(json_data)
     kwargs["statistics_search_dto"] = statistics_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.search_asset_statistics, ctx, **kwargs)
+    result = run_command(client.search.search_asset_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -476,7 +476,7 @@ def search_assets(
     metadata_search_dto = MetadataSearchDto.model_validate(json_data)
     kwargs["metadata_search_dto"] = metadata_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.search_assets, ctx, **kwargs)
+    result = run_command(client.search.search_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -650,7 +650,7 @@ def search_large_assets(
     if with_exif is not None:
         kwargs["with_exif"] = with_exif.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.search_large_assets, ctx, **kwargs)
+    result = run_command(client.search.search_large_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -671,7 +671,7 @@ def search_person(
     if with_hidden is not None:
         kwargs["with_hidden"] = with_hidden.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.search_person, ctx, **kwargs)
+    result = run_command(client.search.search_person, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -687,7 +687,7 @@ def search_places(
     kwargs = {}
     kwargs["name"] = name
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.search_places, ctx, **kwargs)
+    result = run_command(client.search.search_places, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -867,7 +867,7 @@ def search_random(
     random_search_dto = RandomSearchDto.model_validate(json_data)
     kwargs["random_search_dto"] = random_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.search_random, ctx, **kwargs)
+    result = run_command(client.search.search_random, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -1055,5 +1055,5 @@ def search_smart(
     smart_search_dto = SmartSearchDto.model_validate(json_data)
     kwargs["smart_search_dto"] = smart_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search.search_smart, ctx, **kwargs)
+    result = run_command(client.search.search_smart, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/search.py
+++ b/immichpy/cli/commands/search.py
@@ -27,7 +27,7 @@ def get_assets_by_city(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "get_assets_by_city", ctx, **kwargs)
+    result = run_command(client.search.get_assets_by_city, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -41,7 +41,7 @@ def get_explore_data(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "get_explore_data", ctx, **kwargs)
+    result = run_command(client.search.get_explore_data, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,7 +85,7 @@ def get_search_suggestions(
         kwargs["state"] = state
     kwargs["type"] = type
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "get_search_suggestions", ctx, **kwargs)
+    result = run_command(client.search.get_search_suggestions, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -247,7 +247,7 @@ def search_asset_statistics(
     statistics_search_dto = StatisticsSearchDto.model_validate(json_data)
     kwargs["statistics_search_dto"] = statistics_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "search_asset_statistics", ctx, **kwargs)
+    result = run_command(client.search.search_asset_statistics, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -476,7 +476,7 @@ def search_assets(
     metadata_search_dto = MetadataSearchDto.model_validate(json_data)
     kwargs["metadata_search_dto"] = metadata_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "search_assets", ctx, **kwargs)
+    result = run_command(client.search.search_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -650,7 +650,7 @@ def search_large_assets(
     if with_exif is not None:
         kwargs["with_exif"] = with_exif.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "search_large_assets", ctx, **kwargs)
+    result = run_command(client.search.search_large_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -671,7 +671,7 @@ def search_person(
     if with_hidden is not None:
         kwargs["with_hidden"] = with_hidden.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "search_person", ctx, **kwargs)
+    result = run_command(client.search.search_person, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -687,7 +687,7 @@ def search_places(
     kwargs = {}
     kwargs["name"] = name
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "search_places", ctx, **kwargs)
+    result = run_command(client.search.search_places, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -867,7 +867,7 @@ def search_random(
     random_search_dto = RandomSearchDto.model_validate(json_data)
     kwargs["random_search_dto"] = random_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "search_random", ctx, **kwargs)
+    result = run_command(client.search.search_random, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -1055,5 +1055,5 @@ def search_smart(
     smart_search_dto = SmartSearchDto.model_validate(json_data)
     kwargs["smart_search_dto"] = smart_search_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.search, "search_smart", ctx, **kwargs)
+    result = run_command(client.search.search_smart, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/server.py
+++ b/immichpy/cli/commands/server.py
@@ -26,7 +26,7 @@ def delete_server_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.delete_server_license, ctx, **kwargs)
+    result = run_command(client.server.delete_server_license, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -40,7 +40,7 @@ def get_about_info(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_about_info, ctx, **kwargs)
+    result = run_command(client.server.get_about_info, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -54,7 +54,7 @@ def get_apk_links(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_apk_links, ctx, **kwargs)
+    result = run_command(client.server.get_apk_links, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def get_server_config(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_server_config, ctx, **kwargs)
+    result = run_command(client.server.get_server_config, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -82,7 +82,7 @@ def get_server_features(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_server_features, ctx, **kwargs)
+    result = run_command(client.server.get_server_features, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_server_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_server_license, ctx, **kwargs)
+    result = run_command(client.server.get_server_license, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -110,7 +110,7 @@ def get_server_statistics(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_server_statistics, ctx, **kwargs)
+    result = run_command(client.server.get_server_statistics, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -124,7 +124,7 @@ def get_server_version(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_server_version, ctx, **kwargs)
+    result = run_command(client.server.get_server_version, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -138,7 +138,7 @@ def get_storage(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_storage, ctx, **kwargs)
+    result = run_command(client.server.get_storage, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,7 +154,7 @@ def get_supported_media_types(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_supported_media_types, ctx, **kwargs)
+    result = run_command(client.server.get_supported_media_types, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -168,7 +168,7 @@ def get_theme(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_theme, ctx, **kwargs)
+    result = run_command(client.server.get_theme, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -182,7 +182,7 @@ def get_version_check(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_version_check, ctx, **kwargs)
+    result = run_command(client.server.get_version_check, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -196,7 +196,7 @@ def get_version_history(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.get_version_history, ctx, **kwargs)
+    result = run_command(client.server.get_version_history, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -210,7 +210,7 @@ def ping_server(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.ping_server, ctx, **kwargs)
+    result = run_command(client.server.ping_server, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -235,5 +235,5 @@ def set_server_license(
     license_key_dto = LicenseKeyDto.model_validate(json_data)
     kwargs["license_key_dto"] = license_key_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server.set_server_license, ctx, **kwargs)
+    result = run_command(client.server.set_server_license, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/server.py
+++ b/immichpy/cli/commands/server.py
@@ -26,7 +26,7 @@ def delete_server_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "delete_server_license", ctx, **kwargs)
+    result = run_command(client.server.delete_server_license, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -40,7 +40,7 @@ def get_about_info(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_about_info", ctx, **kwargs)
+    result = run_command(client.server.get_about_info, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -54,7 +54,7 @@ def get_apk_links(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_apk_links", ctx, **kwargs)
+    result = run_command(client.server.get_apk_links, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def get_server_config(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_server_config", ctx, **kwargs)
+    result = run_command(client.server.get_server_config, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -82,7 +82,7 @@ def get_server_features(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_server_features", ctx, **kwargs)
+    result = run_command(client.server.get_server_features, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_server_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_server_license", ctx, **kwargs)
+    result = run_command(client.server.get_server_license, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -110,7 +110,7 @@ def get_server_statistics(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_server_statistics", ctx, **kwargs)
+    result = run_command(client.server.get_server_statistics, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -124,7 +124,7 @@ def get_server_version(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_server_version", ctx, **kwargs)
+    result = run_command(client.server.get_server_version, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -138,7 +138,7 @@ def get_storage(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_storage", ctx, **kwargs)
+    result = run_command(client.server.get_storage, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,7 +154,7 @@ def get_supported_media_types(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_supported_media_types", ctx, **kwargs)
+    result = run_command(client.server.get_supported_media_types, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -168,7 +168,7 @@ def get_theme(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_theme", ctx, **kwargs)
+    result = run_command(client.server.get_theme, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -182,7 +182,7 @@ def get_version_check(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_version_check", ctx, **kwargs)
+    result = run_command(client.server.get_version_check, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -196,7 +196,7 @@ def get_version_history(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "get_version_history", ctx, **kwargs)
+    result = run_command(client.server.get_version_history, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -210,7 +210,7 @@ def ping_server(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "ping_server", ctx, **kwargs)
+    result = run_command(client.server.ping_server, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -235,5 +235,5 @@ def set_server_license(
     license_key_dto = LicenseKeyDto.model_validate(json_data)
     kwargs["license_key_dto"] = license_key_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.server, "set_server_license", ctx, **kwargs)
+    result = run_command(client.server.set_server_license, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/server.py
+++ b/immichpy/cli/commands/server.py
@@ -26,7 +26,7 @@ def delete_server_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "delete_server_license", ctx, **kwargs)
+    result = run_command(client.server, "delete_server_license", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -40,7 +40,7 @@ def get_about_info(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_about_info", ctx, **kwargs)
+    result = run_command(client.server, "get_about_info", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -54,7 +54,7 @@ def get_apk_links(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_apk_links", ctx, **kwargs)
+    result = run_command(client.server, "get_apk_links", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def get_server_config(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_server_config", ctx, **kwargs)
+    result = run_command(client.server, "get_server_config", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -82,7 +82,7 @@ def get_server_features(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_server_features", ctx, **kwargs)
+    result = run_command(client.server, "get_server_features", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -96,7 +96,7 @@ def get_server_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_server_license", ctx, **kwargs)
+    result = run_command(client.server, "get_server_license", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -110,7 +110,7 @@ def get_server_statistics(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_server_statistics", ctx, **kwargs)
+    result = run_command(client.server, "get_server_statistics", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -124,7 +124,7 @@ def get_server_version(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_server_version", ctx, **kwargs)
+    result = run_command(client.server, "get_server_version", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -138,7 +138,7 @@ def get_storage(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_storage", ctx, **kwargs)
+    result = run_command(client.server, "get_storage", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,9 +154,7 @@ def get_supported_media_types(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.server, "get_supported_media_types", ctx, **kwargs
-    )
+    result = run_command(client.server, "get_supported_media_types", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -170,7 +168,7 @@ def get_theme(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_theme", ctx, **kwargs)
+    result = run_command(client.server, "get_theme", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -184,7 +182,7 @@ def get_version_check(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_version_check", ctx, **kwargs)
+    result = run_command(client.server, "get_version_check", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -198,7 +196,7 @@ def get_version_history(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "get_version_history", ctx, **kwargs)
+    result = run_command(client.server, "get_version_history", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -212,7 +210,7 @@ def ping_server(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "ping_server", ctx, **kwargs)
+    result = run_command(client.server, "ping_server", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -237,5 +235,5 @@ def set_server_license(
     license_key_dto = LicenseKeyDto.model_validate(json_data)
     kwargs["license_key_dto"] = license_key_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.server, "set_server_license", ctx, **kwargs)
+    result = run_command(client.server, "set_server_license", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/sessions.py
+++ b/immichpy/cli/commands/sessions.py
@@ -42,7 +42,7 @@ def create_session(
     session_create_dto = SessionCreateDto.model_validate(json_data)
     kwargs["session_create_dto"] = session_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions, "create_session", ctx, **kwargs)
+    result = run_command(client.sessions.create_session, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -56,7 +56,7 @@ def delete_all_sessions(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions, "delete_all_sessions", ctx, **kwargs)
+    result = run_command(client.sessions.delete_all_sessions, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -72,7 +72,7 @@ def delete_session(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions, "delete_session", ctx, **kwargs)
+    result = run_command(client.sessions.delete_session, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -86,7 +86,7 @@ def get_sessions(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions, "get_sessions", ctx, **kwargs)
+    result = run_command(client.sessions.get_sessions, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -102,7 +102,7 @@ def lock_session(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions, "lock_session", ctx, **kwargs)
+    result = run_command(client.sessions.lock_session, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -130,5 +130,5 @@ def update_session(
     session_update_dto = SessionUpdateDto.model_validate(json_data)
     kwargs["session_update_dto"] = session_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions, "update_session", ctx, **kwargs)
+    result = run_command(client.sessions.update_session, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/sessions.py
+++ b/immichpy/cli/commands/sessions.py
@@ -42,7 +42,7 @@ def create_session(
     session_create_dto = SessionCreateDto.model_validate(json_data)
     kwargs["session_create_dto"] = session_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sessions, "create_session", ctx, **kwargs)
+    result = run_command(client.sessions, "create_session", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -56,7 +56,7 @@ def delete_all_sessions(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sessions, "delete_all_sessions", ctx, **kwargs)
+    result = run_command(client.sessions, "delete_all_sessions", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -72,7 +72,7 @@ def delete_session(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sessions, "delete_session", ctx, **kwargs)
+    result = run_command(client.sessions, "delete_session", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -86,7 +86,7 @@ def get_sessions(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sessions, "get_sessions", ctx, **kwargs)
+    result = run_command(client.sessions, "get_sessions", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -102,7 +102,7 @@ def lock_session(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sessions, "lock_session", ctx, **kwargs)
+    result = run_command(client.sessions, "lock_session", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -130,5 +130,5 @@ def update_session(
     session_update_dto = SessionUpdateDto.model_validate(json_data)
     kwargs["session_update_dto"] = session_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sessions, "update_session", ctx, **kwargs)
+    result = run_command(client.sessions, "update_session", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/sessions.py
+++ b/immichpy/cli/commands/sessions.py
@@ -42,7 +42,7 @@ def create_session(
     session_create_dto = SessionCreateDto.model_validate(json_data)
     kwargs["session_create_dto"] = session_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions.create_session, ctx, **kwargs)
+    result = run_command(client.sessions.create_session, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -56,7 +56,7 @@ def delete_all_sessions(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions.delete_all_sessions, ctx, **kwargs)
+    result = run_command(client.sessions.delete_all_sessions, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -72,7 +72,7 @@ def delete_session(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions.delete_session, ctx, **kwargs)
+    result = run_command(client.sessions.delete_session, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -86,7 +86,7 @@ def get_sessions(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions.get_sessions, ctx, **kwargs)
+    result = run_command(client.sessions.get_sessions, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -102,7 +102,7 @@ def lock_session(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions.lock_session, ctx, **kwargs)
+    result = run_command(client.sessions.lock_session, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -130,5 +130,5 @@ def update_session(
     session_update_dto = SessionUpdateDto.model_validate(json_data)
     kwargs["session_update_dto"] = session_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sessions.update_session, ctx, **kwargs)
+    result = run_command(client.sessions.update_session, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/shared_links.py
+++ b/immichpy/cli/commands/shared_links.py
@@ -40,7 +40,7 @@ def add_shared_link_assets(
     asset_ids_dto = AssetIdsDto.model_validate(json_data)
     kwargs["asset_ids_dto"] = asset_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "add_shared_link_assets", ctx, **kwargs)
+    result = run_command(client.shared_links.add_shared_link_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -100,7 +100,7 @@ def create_shared_link(
     shared_link_create_dto = SharedLinkCreateDto.model_validate(json_data)
     kwargs["shared_link_create_dto"] = shared_link_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "create_shared_link", ctx, **kwargs)
+    result = run_command(client.shared_links.create_shared_link, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -122,7 +122,7 @@ def get_all_shared_links(
     if id is not None:
         kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "get_all_shared_links", ctx, **kwargs)
+    result = run_command(client.shared_links.get_all_shared_links, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,7 +154,7 @@ Example: password""",
     if token is not None:
         kwargs["token"] = token
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "get_my_shared_link", ctx, **kwargs)
+    result = run_command(client.shared_links.get_my_shared_link, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -170,7 +170,7 @@ def get_shared_link_by_id(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "get_shared_link_by_id", ctx, **kwargs)
+    result = run_command(client.shared_links.get_shared_link_by_id, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -186,7 +186,7 @@ def remove_shared_link(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "remove_shared_link", ctx, **kwargs)
+    result = run_command(client.shared_links.remove_shared_link, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -209,9 +209,7 @@ def remove_shared_link_assets(
     asset_ids_dto = AssetIdsDto.model_validate(json_data)
     kwargs["asset_ids_dto"] = asset_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.shared_links, "remove_shared_link_assets", ctx, **kwargs
-    )
+    result = run_command(client.shared_links.remove_shared_link_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -242,7 +240,7 @@ Example: password""",
     shared_link_login_dto = SharedLinkLoginDto.model_validate(json_data)
     kwargs["shared_link_login_dto"] = shared_link_login_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "shared_link_login", ctx, **kwargs)
+    result = run_command(client.shared_links.shared_link_login, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -301,5 +299,5 @@ def update_shared_link(
     shared_link_edit_dto = SharedLinkEditDto.model_validate(json_data)
     kwargs["shared_link_edit_dto"] = shared_link_edit_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links, "update_shared_link", ctx, **kwargs)
+    result = run_command(client.shared_links.update_shared_link, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/shared_links.py
+++ b/immichpy/cli/commands/shared_links.py
@@ -40,7 +40,7 @@ def add_shared_link_assets(
     asset_ids_dto = AssetIdsDto.model_validate(json_data)
     kwargs["asset_ids_dto"] = asset_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.add_shared_link_assets, ctx, **kwargs)
+    result = run_command(client.shared_links.add_shared_link_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -100,7 +100,7 @@ def create_shared_link(
     shared_link_create_dto = SharedLinkCreateDto.model_validate(json_data)
     kwargs["shared_link_create_dto"] = shared_link_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.create_shared_link, ctx, **kwargs)
+    result = run_command(client.shared_links.create_shared_link, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -122,7 +122,7 @@ def get_all_shared_links(
     if id is not None:
         kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.get_all_shared_links, ctx, **kwargs)
+    result = run_command(client.shared_links.get_all_shared_links, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -154,7 +154,7 @@ Example: password""",
     if token is not None:
         kwargs["token"] = token
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.get_my_shared_link, ctx, **kwargs)
+    result = run_command(client.shared_links.get_my_shared_link, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -170,7 +170,7 @@ def get_shared_link_by_id(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.get_shared_link_by_id, ctx, **kwargs)
+    result = run_command(client.shared_links.get_shared_link_by_id, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -186,7 +186,7 @@ def remove_shared_link(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.remove_shared_link, ctx, **kwargs)
+    result = run_command(client.shared_links.remove_shared_link, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -209,7 +209,9 @@ def remove_shared_link_assets(
     asset_ids_dto = AssetIdsDto.model_validate(json_data)
     kwargs["asset_ids_dto"] = asset_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.remove_shared_link_assets, ctx, **kwargs)
+    result = run_command(
+        client.shared_links.remove_shared_link_assets, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -240,7 +242,7 @@ Example: password""",
     shared_link_login_dto = SharedLinkLoginDto.model_validate(json_data)
     kwargs["shared_link_login_dto"] = shared_link_login_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.shared_link_login, ctx, **kwargs)
+    result = run_command(client.shared_links.shared_link_login, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -299,5 +301,5 @@ def update_shared_link(
     shared_link_edit_dto = SharedLinkEditDto.model_validate(json_data)
     kwargs["shared_link_edit_dto"] = shared_link_edit_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.shared_links.update_shared_link, ctx, **kwargs)
+    result = run_command(client.shared_links.update_shared_link, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/shared_links.py
+++ b/immichpy/cli/commands/shared_links.py
@@ -40,9 +40,7 @@ def add_shared_link_assets(
     asset_ids_dto = AssetIdsDto.model_validate(json_data)
     kwargs["asset_ids_dto"] = asset_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "add_shared_link_assets", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "add_shared_link_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -102,9 +100,7 @@ def create_shared_link(
     shared_link_create_dto = SharedLinkCreateDto.model_validate(json_data)
     kwargs["shared_link_create_dto"] = shared_link_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "create_shared_link", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "create_shared_link", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -126,9 +122,7 @@ def get_all_shared_links(
     if id is not None:
         kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "get_all_shared_links", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "get_all_shared_links", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -160,9 +154,7 @@ Example: password""",
     if token is not None:
         kwargs["token"] = token
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "get_my_shared_link", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "get_my_shared_link", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -178,9 +170,7 @@ def get_shared_link_by_id(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "get_shared_link_by_id", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "get_shared_link_by_id", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -196,9 +186,7 @@ def remove_shared_link(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "remove_shared_link", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "remove_shared_link", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -222,7 +210,7 @@ def remove_shared_link_assets(
     kwargs["asset_ids_dto"] = asset_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.shared_links, "remove_shared_link_assets", ctx, **kwargs
+        client.shared_links, "remove_shared_link_assets", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -254,9 +242,7 @@ Example: password""",
     shared_link_login_dto = SharedLinkLoginDto.model_validate(json_data)
     kwargs["shared_link_login_dto"] = shared_link_login_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "shared_link_login", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "shared_link_login", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -315,7 +301,5 @@ def update_shared_link(
     shared_link_edit_dto = SharedLinkEditDto.model_validate(json_data)
     kwargs["shared_link_edit_dto"] = shared_link_edit_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.shared_links, "update_shared_link", ctx, **kwargs
-    )
+    result = run_command(client.shared_links, "update_shared_link", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/stacks.py
+++ b/immichpy/cli/commands/stacks.py
@@ -33,7 +33,7 @@ def create_stack(
     stack_create_dto = StackCreateDto.model_validate(json_data)
     kwargs["stack_create_dto"] = stack_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks.create_stack, ctx, **kwargs)
+    result = run_command(client.stacks.create_stack, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -49,7 +49,7 @@ def delete_stack(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks.delete_stack, ctx, **kwargs)
+    result = run_command(client.stacks.delete_stack, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def delete_stacks(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks.delete_stacks, ctx, **kwargs)
+    result = run_command(client.stacks.delete_stacks, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,7 +84,7 @@ def get_stack(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks.get_stack, ctx, **kwargs)
+    result = run_command(client.stacks.get_stack, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def remove_asset_from_stack(
     kwargs["asset_id"] = asset_id
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks.remove_asset_from_stack, ctx, **kwargs)
+    result = run_command(client.stacks.remove_asset_from_stack, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -123,7 +123,7 @@ def search_stacks(
     if primary_asset_id is not None:
         kwargs["primary_asset_id"] = primary_asset_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks.search_stacks, ctx, **kwargs)
+    result = run_command(client.stacks.search_stacks, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -147,5 +147,5 @@ def update_stack(
     stack_update_dto = StackUpdateDto.model_validate(json_data)
     kwargs["stack_update_dto"] = stack_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks.update_stack, ctx, **kwargs)
+    result = run_command(client.stacks.update_stack, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/stacks.py
+++ b/immichpy/cli/commands/stacks.py
@@ -33,7 +33,7 @@ def create_stack(
     stack_create_dto = StackCreateDto.model_validate(json_data)
     kwargs["stack_create_dto"] = stack_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks, "create_stack", ctx, **kwargs)
+    result = run_command(client.stacks.create_stack, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -49,7 +49,7 @@ def delete_stack(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks, "delete_stack", ctx, **kwargs)
+    result = run_command(client.stacks.delete_stack, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def delete_stacks(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks, "delete_stacks", ctx, **kwargs)
+    result = run_command(client.stacks.delete_stacks, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,7 +84,7 @@ def get_stack(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks, "get_stack", ctx, **kwargs)
+    result = run_command(client.stacks.get_stack, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def remove_asset_from_stack(
     kwargs["asset_id"] = asset_id
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks, "remove_asset_from_stack", ctx, **kwargs)
+    result = run_command(client.stacks.remove_asset_from_stack, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -123,7 +123,7 @@ def search_stacks(
     if primary_asset_id is not None:
         kwargs["primary_asset_id"] = primary_asset_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks, "search_stacks", ctx, **kwargs)
+    result = run_command(client.stacks.search_stacks, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -147,5 +147,5 @@ def update_stack(
     stack_update_dto = StackUpdateDto.model_validate(json_data)
     kwargs["stack_update_dto"] = stack_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.stacks, "update_stack", ctx, **kwargs)
+    result = run_command(client.stacks.update_stack, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/stacks.py
+++ b/immichpy/cli/commands/stacks.py
@@ -33,7 +33,7 @@ def create_stack(
     stack_create_dto = StackCreateDto.model_validate(json_data)
     kwargs["stack_create_dto"] = stack_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.stacks, "create_stack", ctx, **kwargs)
+    result = run_command(client.stacks, "create_stack", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -49,7 +49,7 @@ def delete_stack(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.stacks, "delete_stack", ctx, **kwargs)
+    result = run_command(client.stacks, "delete_stack", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -68,7 +68,7 @@ def delete_stacks(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.stacks, "delete_stacks", ctx, **kwargs)
+    result = run_command(client.stacks, "delete_stacks", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -84,7 +84,7 @@ def get_stack(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.stacks, "get_stack", ctx, **kwargs)
+    result = run_command(client.stacks, "get_stack", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,9 +104,7 @@ def remove_asset_from_stack(
     kwargs["asset_id"] = asset_id
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.stacks, "remove_asset_from_stack", ctx, **kwargs
-    )
+    result = run_command(client.stacks, "remove_asset_from_stack", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -125,7 +123,7 @@ def search_stacks(
     if primary_asset_id is not None:
         kwargs["primary_asset_id"] = primary_asset_id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.stacks, "search_stacks", ctx, **kwargs)
+    result = run_command(client.stacks, "search_stacks", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -149,5 +147,5 @@ def update_stack(
     stack_update_dto = StackUpdateDto.model_validate(json_data)
     kwargs["stack_update_dto"] = stack_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.stacks, "update_stack", ctx, **kwargs)
+    result = run_command(client.stacks, "update_stack", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/sync.py
+++ b/immichpy/cli/commands/sync.py
@@ -35,7 +35,7 @@ def delete_sync_ack(
     sync_ack_delete_dto = SyncAckDeleteDto.model_validate(json_data)
     kwargs["sync_ack_delete_dto"] = sync_ack_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync.delete_sync_ack, ctx, **kwargs)
+    result = run_command(client.sync.delete_sync_ack, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -58,7 +58,7 @@ def get_delta_sync(
     asset_delta_sync_dto = AssetDeltaSyncDto.model_validate(json_data)
     kwargs["asset_delta_sync_dto"] = asset_delta_sync_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync.get_delta_sync, ctx, **kwargs)
+    result = run_command(client.sync.get_delta_sync, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -91,7 +91,7 @@ def get_full_sync_for_user(
     asset_full_sync_dto = AssetFullSyncDto.model_validate(json_data)
     kwargs["asset_full_sync_dto"] = asset_full_sync_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync.get_full_sync_for_user, ctx, **kwargs)
+    result = run_command(client.sync.get_full_sync_for_user, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -105,7 +105,7 @@ def get_sync_ack(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync.get_sync_ack, ctx, **kwargs)
+    result = run_command(client.sync.get_sync_ack, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -131,7 +131,7 @@ def get_sync_stream(
     sync_stream_dto = SyncStreamDto.model_validate(json_data)
     kwargs["sync_stream_dto"] = sync_stream_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync.get_sync_stream, ctx, **kwargs)
+    result = run_command(client.sync.get_sync_stream, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -152,5 +152,5 @@ def send_sync_ack(
     sync_ack_set_dto = SyncAckSetDto.model_validate(json_data)
     kwargs["sync_ack_set_dto"] = sync_ack_set_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync.send_sync_ack, ctx, **kwargs)
+    result = run_command(client.sync.send_sync_ack, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/sync.py
+++ b/immichpy/cli/commands/sync.py
@@ -35,7 +35,7 @@ def delete_sync_ack(
     sync_ack_delete_dto = SyncAckDeleteDto.model_validate(json_data)
     kwargs["sync_ack_delete_dto"] = sync_ack_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync, "delete_sync_ack", ctx, **kwargs)
+    result = run_command(client.sync.delete_sync_ack, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -58,7 +58,7 @@ def get_delta_sync(
     asset_delta_sync_dto = AssetDeltaSyncDto.model_validate(json_data)
     kwargs["asset_delta_sync_dto"] = asset_delta_sync_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync, "get_delta_sync", ctx, **kwargs)
+    result = run_command(client.sync.get_delta_sync, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -91,7 +91,7 @@ def get_full_sync_for_user(
     asset_full_sync_dto = AssetFullSyncDto.model_validate(json_data)
     kwargs["asset_full_sync_dto"] = asset_full_sync_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync, "get_full_sync_for_user", ctx, **kwargs)
+    result = run_command(client.sync.get_full_sync_for_user, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -105,7 +105,7 @@ def get_sync_ack(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync, "get_sync_ack", ctx, **kwargs)
+    result = run_command(client.sync.get_sync_ack, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -131,7 +131,7 @@ def get_sync_stream(
     sync_stream_dto = SyncStreamDto.model_validate(json_data)
     kwargs["sync_stream_dto"] = sync_stream_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync, "get_sync_stream", ctx, **kwargs)
+    result = run_command(client.sync.get_sync_stream, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -152,5 +152,5 @@ def send_sync_ack(
     sync_ack_set_dto = SyncAckSetDto.model_validate(json_data)
     kwargs["sync_ack_set_dto"] = sync_ack_set_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.sync, "send_sync_ack", ctx, **kwargs)
+    result = run_command(client.sync.send_sync_ack, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/sync.py
+++ b/immichpy/cli/commands/sync.py
@@ -35,7 +35,7 @@ def delete_sync_ack(
     sync_ack_delete_dto = SyncAckDeleteDto.model_validate(json_data)
     kwargs["sync_ack_delete_dto"] = sync_ack_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sync, "delete_sync_ack", ctx, **kwargs)
+    result = run_command(client.sync, "delete_sync_ack", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -58,7 +58,7 @@ def get_delta_sync(
     asset_delta_sync_dto = AssetDeltaSyncDto.model_validate(json_data)
     kwargs["asset_delta_sync_dto"] = asset_delta_sync_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sync, "get_delta_sync", ctx, **kwargs)
+    result = run_command(client.sync, "get_delta_sync", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -91,7 +91,7 @@ def get_full_sync_for_user(
     asset_full_sync_dto = AssetFullSyncDto.model_validate(json_data)
     kwargs["asset_full_sync_dto"] = asset_full_sync_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sync, "get_full_sync_for_user", ctx, **kwargs)
+    result = run_command(client.sync, "get_full_sync_for_user", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -105,7 +105,7 @@ def get_sync_ack(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sync, "get_sync_ack", ctx, **kwargs)
+    result = run_command(client.sync, "get_sync_ack", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -131,7 +131,7 @@ def get_sync_stream(
     sync_stream_dto = SyncStreamDto.model_validate(json_data)
     kwargs["sync_stream_dto"] = sync_stream_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sync, "get_sync_stream", ctx, **kwargs)
+    result = run_command(client.sync, "get_sync_stream", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -152,5 +152,5 @@ def send_sync_ack(
     sync_ack_set_dto = SyncAckSetDto.model_validate(json_data)
     kwargs["sync_ack_set_dto"] = sync_ack_set_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.sync, "send_sync_ack", ctx, **kwargs)
+    result = run_command(client.sync, "send_sync_ack", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/system_config.py
+++ b/immichpy/cli/commands/system_config.py
@@ -26,7 +26,7 @@ def get_config(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_config.get_config, ctx, **kwargs)
+    result = run_command(client.system_config.get_config, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -40,7 +40,7 @@ def get_config_defaults(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_config.get_config_defaults, ctx, **kwargs)
+    result = run_command(client.system_config.get_config_defaults, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -57,7 +57,7 @@ def get_storage_template_options(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.system_config.get_storage_template_options, ctx, **kwargs
+        client.system_config.get_storage_template_options, ctx=ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -776,5 +776,5 @@ def update_config(
     system_config_dto = SystemConfigDto.model_validate(json_data)
     kwargs["system_config_dto"] = system_config_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_config.update_config, ctx, **kwargs)
+    result = run_command(client.system_config.update_config, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/system_config.py
+++ b/immichpy/cli/commands/system_config.py
@@ -26,7 +26,7 @@ def get_config(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_config, "get_config", ctx, **kwargs)
+    result = run_command(client.system_config.get_config, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -40,7 +40,7 @@ def get_config_defaults(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_config, "get_config_defaults", ctx, **kwargs)
+    result = run_command(client.system_config.get_config_defaults, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -57,7 +57,7 @@ def get_storage_template_options(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.system_config, "get_storage_template_options", ctx, **kwargs
+        client.system_config.get_storage_template_options, ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -776,5 +776,5 @@ def update_config(
     system_config_dto = SystemConfigDto.model_validate(json_data)
     kwargs["system_config_dto"] = system_config_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_config, "update_config", ctx, **kwargs)
+    result = run_command(client.system_config.update_config, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/system_config.py
+++ b/immichpy/cli/commands/system_config.py
@@ -26,7 +26,7 @@ def get_config(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.system_config, "get_config", ctx, **kwargs)
+    result = run_command(client.system_config, "get_config", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -40,9 +40,7 @@ def get_config_defaults(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.system_config, "get_config_defaults", ctx, **kwargs
-    )
+    result = run_command(client.system_config, "get_config_defaults", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -59,7 +57,7 @@ def get_storage_template_options(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.system_config, "get_storage_template_options", ctx, **kwargs
+        client.system_config, "get_storage_template_options", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -778,5 +776,5 @@ def update_config(
     system_config_dto = SystemConfigDto.model_validate(json_data)
     kwargs["system_config_dto"] = system_config_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.system_config, "update_config", ctx, **kwargs)
+    result = run_command(client.system_config, "update_config", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/system_metadata.py
+++ b/immichpy/cli/commands/system_metadata.py
@@ -26,9 +26,7 @@ def get_admin_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.system_metadata, "get_admin_onboarding", ctx, **kwargs
-    )
+    result = run_command(client.system_metadata, "get_admin_onboarding", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -45,7 +43,7 @@ def get_reverse_geocoding_state(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.system_metadata, "get_reverse_geocoding_state", ctx, **kwargs
+        client.system_metadata, "get_reverse_geocoding_state", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -63,7 +61,7 @@ def get_version_check_state(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.system_metadata, "get_version_check_state", ctx, **kwargs
+        client.system_metadata, "get_version_check_state", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -88,6 +86,6 @@ def update_admin_onboarding(
     kwargs["admin_onboarding_update_dto"] = admin_onboarding_update_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.system_metadata, "update_admin_onboarding", ctx, **kwargs
+        client.system_metadata, "update_admin_onboarding", ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/system_metadata.py
+++ b/immichpy/cli/commands/system_metadata.py
@@ -26,7 +26,7 @@ def get_admin_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_metadata, "get_admin_onboarding", ctx, **kwargs)
+    result = run_command(client.system_metadata.get_admin_onboarding, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -43,7 +43,7 @@ def get_reverse_geocoding_state(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.system_metadata, "get_reverse_geocoding_state", ctx, **kwargs
+        client.system_metadata.get_reverse_geocoding_state, ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -60,9 +60,7 @@ def get_version_check_state(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.system_metadata, "get_version_check_state", ctx, **kwargs
-    )
+    result = run_command(client.system_metadata.get_version_check_state, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -85,7 +83,5 @@ def update_admin_onboarding(
     admin_onboarding_update_dto = AdminOnboardingUpdateDto.model_validate(json_data)
     kwargs["admin_onboarding_update_dto"] = admin_onboarding_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.system_metadata, "update_admin_onboarding", ctx, **kwargs
-    )
+    result = run_command(client.system_metadata.update_admin_onboarding, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/system_metadata.py
+++ b/immichpy/cli/commands/system_metadata.py
@@ -26,7 +26,7 @@ def get_admin_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_metadata.get_admin_onboarding, ctx, **kwargs)
+    result = run_command(client.system_metadata.get_admin_onboarding, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -43,7 +43,7 @@ def get_reverse_geocoding_state(
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.system_metadata.get_reverse_geocoding_state, ctx, **kwargs
+        client.system_metadata.get_reverse_geocoding_state, ctx=ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -60,7 +60,9 @@ def get_version_check_state(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_metadata.get_version_check_state, ctx, **kwargs)
+    result = run_command(
+        client.system_metadata.get_version_check_state, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -83,5 +85,7 @@ def update_admin_onboarding(
     admin_onboarding_update_dto = AdminOnboardingUpdateDto.model_validate(json_data)
     kwargs["admin_onboarding_update_dto"] = admin_onboarding_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.system_metadata.update_admin_onboarding, ctx, **kwargs)
+    result = run_command(
+        client.system_metadata.update_admin_onboarding, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)

--- a/immichpy/cli/commands/tags.py
+++ b/immichpy/cli/commands/tags.py
@@ -33,7 +33,7 @@ def bulk_tag_assets(
     tag_bulk_assets_dto = TagBulkAssetsDto.model_validate(json_data)
     kwargs["tag_bulk_assets_dto"] = tag_bulk_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "bulk_tag_assets", ctx, **kwargs)
+    result = run_command(client.tags.bulk_tag_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -58,7 +58,7 @@ def create_tag(
     tag_create_dto = TagCreateDto.model_validate(json_data)
     kwargs["tag_create_dto"] = tag_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "create_tag", ctx, **kwargs)
+    result = run_command(client.tags.create_tag, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -74,7 +74,7 @@ def delete_tag(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "delete_tag", ctx, **kwargs)
+    result = run_command(client.tags.delete_tag, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,7 +88,7 @@ def get_all_tags(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "get_all_tags", ctx, **kwargs)
+    result = run_command(client.tags.get_all_tags, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def get_tag_by_id(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "get_tag_by_id", ctx, **kwargs)
+    result = run_command(client.tags.get_tag_by_id, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -125,7 +125,7 @@ def tag_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "tag_assets", ctx, **kwargs)
+    result = run_command(client.tags.tag_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -146,7 +146,7 @@ def untag_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "untag_assets", ctx, **kwargs)
+    result = run_command(client.tags.untag_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -168,7 +168,7 @@ def update_tag(
     tag_update_dto = TagUpdateDto.model_validate(json_data)
     kwargs["tag_update_dto"] = tag_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "update_tag", ctx, **kwargs)
+    result = run_command(client.tags.update_tag, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -187,5 +187,5 @@ def upsert_tags(
     tag_upsert_dto = TagUpsertDto.model_validate(json_data)
     kwargs["tag_upsert_dto"] = tag_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags, "upsert_tags", ctx, **kwargs)
+    result = run_command(client.tags.upsert_tags, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/tags.py
+++ b/immichpy/cli/commands/tags.py
@@ -33,7 +33,7 @@ def bulk_tag_assets(
     tag_bulk_assets_dto = TagBulkAssetsDto.model_validate(json_data)
     kwargs["tag_bulk_assets_dto"] = tag_bulk_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.bulk_tag_assets, ctx, **kwargs)
+    result = run_command(client.tags.bulk_tag_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -58,7 +58,7 @@ def create_tag(
     tag_create_dto = TagCreateDto.model_validate(json_data)
     kwargs["tag_create_dto"] = tag_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.create_tag, ctx, **kwargs)
+    result = run_command(client.tags.create_tag, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -74,7 +74,7 @@ def delete_tag(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.delete_tag, ctx, **kwargs)
+    result = run_command(client.tags.delete_tag, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,7 +88,7 @@ def get_all_tags(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.get_all_tags, ctx, **kwargs)
+    result = run_command(client.tags.get_all_tags, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def get_tag_by_id(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.get_tag_by_id, ctx, **kwargs)
+    result = run_command(client.tags.get_tag_by_id, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -125,7 +125,7 @@ def tag_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.tag_assets, ctx, **kwargs)
+    result = run_command(client.tags.tag_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -146,7 +146,7 @@ def untag_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.untag_assets, ctx, **kwargs)
+    result = run_command(client.tags.untag_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -168,7 +168,7 @@ def update_tag(
     tag_update_dto = TagUpdateDto.model_validate(json_data)
     kwargs["tag_update_dto"] = tag_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.update_tag, ctx, **kwargs)
+    result = run_command(client.tags.update_tag, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -187,5 +187,5 @@ def upsert_tags(
     tag_upsert_dto = TagUpsertDto.model_validate(json_data)
     kwargs["tag_upsert_dto"] = tag_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.tags.upsert_tags, ctx, **kwargs)
+    result = run_command(client.tags.upsert_tags, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/tags.py
+++ b/immichpy/cli/commands/tags.py
@@ -33,7 +33,7 @@ def bulk_tag_assets(
     tag_bulk_assets_dto = TagBulkAssetsDto.model_validate(json_data)
     kwargs["tag_bulk_assets_dto"] = tag_bulk_assets_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "bulk_tag_assets", ctx, **kwargs)
+    result = run_command(client.tags, "bulk_tag_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -58,7 +58,7 @@ def create_tag(
     tag_create_dto = TagCreateDto.model_validate(json_data)
     kwargs["tag_create_dto"] = tag_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "create_tag", ctx, **kwargs)
+    result = run_command(client.tags, "create_tag", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -74,7 +74,7 @@ def delete_tag(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "delete_tag", ctx, **kwargs)
+    result = run_command(client.tags, "delete_tag", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -88,7 +88,7 @@ def get_all_tags(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "get_all_tags", ctx, **kwargs)
+    result = run_command(client.tags, "get_all_tags", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def get_tag_by_id(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "get_tag_by_id", ctx, **kwargs)
+    result = run_command(client.tags, "get_tag_by_id", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -125,7 +125,7 @@ def tag_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "tag_assets", ctx, **kwargs)
+    result = run_command(client.tags, "tag_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -146,7 +146,7 @@ def untag_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "untag_assets", ctx, **kwargs)
+    result = run_command(client.tags, "untag_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -168,7 +168,7 @@ def update_tag(
     tag_update_dto = TagUpdateDto.model_validate(json_data)
     kwargs["tag_update_dto"] = tag_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "update_tag", ctx, **kwargs)
+    result = run_command(client.tags, "update_tag", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -187,5 +187,5 @@ def upsert_tags(
     tag_upsert_dto = TagUpsertDto.model_validate(json_data)
     kwargs["tag_upsert_dto"] = tag_upsert_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.tags, "upsert_tags", ctx, **kwargs)
+    result = run_command(client.tags, "upsert_tags", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/timeline.py
+++ b/immichpy/cli/commands/timeline.py
@@ -116,7 +116,7 @@ Example: 2024-01-01""",
     if with_stacked is not None:
         kwargs["with_stacked"] = with_stacked.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.timeline.get_time_bucket, ctx, **kwargs)
+    result = run_command(client.timeline.get_time_bucket, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -212,5 +212,5 @@ Example: 11.075683,49.416711,11.117589,49.454875""",
     if with_stacked is not None:
         kwargs["with_stacked"] = with_stacked.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.timeline.get_time_buckets, ctx, **kwargs)
+    result = run_command(client.timeline.get_time_buckets, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/timeline.py
+++ b/immichpy/cli/commands/timeline.py
@@ -116,7 +116,7 @@ Example: 2024-01-01""",
     if with_stacked is not None:
         kwargs["with_stacked"] = with_stacked.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.timeline, "get_time_bucket", ctx, **kwargs)
+    result = run_command(client.timeline, "get_time_bucket", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -212,5 +212,5 @@ Example: 11.075683,49.416711,11.117589,49.454875""",
     if with_stacked is not None:
         kwargs["with_stacked"] = with_stacked.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.timeline, "get_time_buckets", ctx, **kwargs)
+    result = run_command(client.timeline, "get_time_buckets", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/timeline.py
+++ b/immichpy/cli/commands/timeline.py
@@ -116,7 +116,7 @@ Example: 2024-01-01""",
     if with_stacked is not None:
         kwargs["with_stacked"] = with_stacked.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.timeline, "get_time_bucket", ctx, **kwargs)
+    result = run_command(client.timeline.get_time_bucket, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -212,5 +212,5 @@ Example: 11.075683,49.416711,11.117589,49.454875""",
     if with_stacked is not None:
         kwargs["with_stacked"] = with_stacked.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.timeline, "get_time_buckets", ctx, **kwargs)
+    result = run_command(client.timeline.get_time_buckets, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/trash.py
+++ b/immichpy/cli/commands/trash.py
@@ -26,7 +26,7 @@ def empty_trash(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.trash, "empty_trash", ctx, **kwargs)
+    result = run_command(client.trash.empty_trash, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -45,7 +45,7 @@ def restore_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.trash, "restore_assets", ctx, **kwargs)
+    result = run_command(client.trash.restore_assets, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -59,5 +59,5 @@ def restore_trash(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.trash, "restore_trash", ctx, **kwargs)
+    result = run_command(client.trash.restore_trash, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/trash.py
+++ b/immichpy/cli/commands/trash.py
@@ -26,7 +26,7 @@ def empty_trash(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.trash.empty_trash, ctx, **kwargs)
+    result = run_command(client.trash.empty_trash, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -45,7 +45,7 @@ def restore_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.trash.restore_assets, ctx, **kwargs)
+    result = run_command(client.trash.restore_assets, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -59,5 +59,5 @@ def restore_trash(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.trash.restore_trash, ctx, **kwargs)
+    result = run_command(client.trash.restore_trash, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/trash.py
+++ b/immichpy/cli/commands/trash.py
@@ -26,7 +26,7 @@ def empty_trash(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.trash, "empty_trash", ctx, **kwargs)
+    result = run_command(client.trash, "empty_trash", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -45,7 +45,7 @@ def restore_assets(
     bulk_ids_dto = BulkIdsDto.model_validate(json_data)
     kwargs["bulk_ids_dto"] = bulk_ids_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.trash, "restore_assets", ctx, **kwargs)
+    result = run_command(client.trash, "restore_assets", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -59,5 +59,5 @@ def restore_trash(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.trash, "restore_trash", ctx, **kwargs)
+    result = run_command(client.trash, "restore_trash", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/users.py
+++ b/immichpy/cli/commands/users.py
@@ -33,7 +33,7 @@ def create_profile_image(
     kwargs["file"] = (file.name, file.read_bytes())
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "create_profile_image", ctx, **kwargs)
+    result = run_command(client.users, "create_profile_image", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -47,7 +47,7 @@ def delete_profile_image(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "delete_profile_image", ctx, **kwargs)
+    result = run_command(client.users, "delete_profile_image", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -61,7 +61,7 @@ def delete_user_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "delete_user_license", ctx, **kwargs)
+    result = run_command(client.users, "delete_user_license", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,7 +75,7 @@ def delete_user_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "delete_user_onboarding", ctx, **kwargs)
+    result = run_command(client.users, "delete_user_onboarding", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -89,7 +89,7 @@ def get_my_preferences(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "get_my_preferences", ctx, **kwargs)
+    result = run_command(client.users, "get_my_preferences", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -103,7 +103,7 @@ def get_my_user(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "get_my_user", ctx, **kwargs)
+    result = run_command(client.users, "get_my_user", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -119,7 +119,7 @@ def get_profile_image(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "get_profile_image", ctx, **kwargs)
+    result = run_command(client.users, "get_profile_image", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -135,7 +135,7 @@ def get_user(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "get_user", ctx, **kwargs)
+    result = run_command(client.users, "get_user", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -149,7 +149,7 @@ def get_user_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "get_user_license", ctx, **kwargs)
+    result = run_command(client.users, "get_user_license", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -163,7 +163,7 @@ def get_user_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "get_user_onboarding", ctx, **kwargs)
+    result = run_command(client.users, "get_user_onboarding", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def search_users(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "search_users", ctx, **kwargs)
+    result = run_command(client.users, "search_users", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -202,7 +202,7 @@ def set_user_license(
     license_key_dto = LicenseKeyDto.model_validate(json_data)
     kwargs["license_key_dto"] = license_key_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "set_user_license", ctx, **kwargs)
+    result = run_command(client.users, "set_user_license", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -223,7 +223,7 @@ def set_user_onboarding(
     onboarding_dto = OnboardingDto.model_validate(json_data)
     kwargs["onboarding_dto"] = onboarding_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "set_user_onboarding", ctx, **kwargs)
+    result = run_command(client.users, "set_user_onboarding", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -395,7 +395,7 @@ def update_my_preferences(
     user_preferences_update_dto = UserPreferencesUpdateDto.model_validate(json_data)
     kwargs["user_preferences_update_dto"] = user_preferences_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "update_my_preferences", ctx, **kwargs)
+    result = run_command(client.users, "update_my_preferences", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -430,5 +430,5 @@ def update_my_user(
     user_update_me_dto = UserUpdateMeDto.model_validate(json_data)
     kwargs["user_update_me_dto"] = user_update_me_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users, "update_my_user", ctx, **kwargs)
+    result = run_command(client.users, "update_my_user", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/users.py
+++ b/immichpy/cli/commands/users.py
@@ -33,7 +33,7 @@ def create_profile_image(
     kwargs["file"] = (file.name, file.read_bytes())
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.create_profile_image, ctx, **kwargs)
+    result = run_command(client.users.create_profile_image, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -47,7 +47,7 @@ def delete_profile_image(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.delete_profile_image, ctx, **kwargs)
+    result = run_command(client.users.delete_profile_image, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -61,7 +61,7 @@ def delete_user_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.delete_user_license, ctx, **kwargs)
+    result = run_command(client.users.delete_user_license, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,7 +75,7 @@ def delete_user_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.delete_user_onboarding, ctx, **kwargs)
+    result = run_command(client.users.delete_user_onboarding, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -89,7 +89,7 @@ def get_my_preferences(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.get_my_preferences, ctx, **kwargs)
+    result = run_command(client.users.get_my_preferences, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -103,7 +103,7 @@ def get_my_user(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.get_my_user, ctx, **kwargs)
+    result = run_command(client.users.get_my_user, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -119,7 +119,7 @@ def get_profile_image(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.get_profile_image, ctx, **kwargs)
+    result = run_command(client.users.get_profile_image, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -135,7 +135,7 @@ def get_user(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.get_user, ctx, **kwargs)
+    result = run_command(client.users.get_user, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -149,7 +149,7 @@ def get_user_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.get_user_license, ctx, **kwargs)
+    result = run_command(client.users.get_user_license, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -163,7 +163,7 @@ def get_user_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.get_user_onboarding, ctx, **kwargs)
+    result = run_command(client.users.get_user_onboarding, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def search_users(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.search_users, ctx, **kwargs)
+    result = run_command(client.users.search_users, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -202,7 +202,7 @@ def set_user_license(
     license_key_dto = LicenseKeyDto.model_validate(json_data)
     kwargs["license_key_dto"] = license_key_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.set_user_license, ctx, **kwargs)
+    result = run_command(client.users.set_user_license, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -223,7 +223,7 @@ def set_user_onboarding(
     onboarding_dto = OnboardingDto.model_validate(json_data)
     kwargs["onboarding_dto"] = onboarding_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.set_user_onboarding, ctx, **kwargs)
+    result = run_command(client.users.set_user_onboarding, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -395,7 +395,7 @@ def update_my_preferences(
     user_preferences_update_dto = UserPreferencesUpdateDto.model_validate(json_data)
     kwargs["user_preferences_update_dto"] = user_preferences_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.update_my_preferences, ctx, **kwargs)
+    result = run_command(client.users.update_my_preferences, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -430,5 +430,5 @@ def update_my_user(
     user_update_me_dto = UserUpdateMeDto.model_validate(json_data)
     kwargs["user_update_me_dto"] = user_update_me_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.update_my_user, ctx, **kwargs)
+    result = run_command(client.users.update_my_user, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/users.py
+++ b/immichpy/cli/commands/users.py
@@ -33,7 +33,7 @@ def create_profile_image(
     kwargs["file"] = (file.name, file.read_bytes())
     kwargs.update(json_data)
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "create_profile_image", ctx, **kwargs)
+    result = run_command(client.users.create_profile_image, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -47,7 +47,7 @@ def delete_profile_image(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "delete_profile_image", ctx, **kwargs)
+    result = run_command(client.users.delete_profile_image, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -61,7 +61,7 @@ def delete_user_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "delete_user_license", ctx, **kwargs)
+    result = run_command(client.users.delete_user_license, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -75,7 +75,7 @@ def delete_user_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "delete_user_onboarding", ctx, **kwargs)
+    result = run_command(client.users.delete_user_onboarding, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -89,7 +89,7 @@ def get_my_preferences(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "get_my_preferences", ctx, **kwargs)
+    result = run_command(client.users.get_my_preferences, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -103,7 +103,7 @@ def get_my_user(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "get_my_user", ctx, **kwargs)
+    result = run_command(client.users.get_my_user, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -119,7 +119,7 @@ def get_profile_image(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "get_profile_image", ctx, **kwargs)
+    result = run_command(client.users.get_profile_image, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -135,7 +135,7 @@ def get_user(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "get_user", ctx, **kwargs)
+    result = run_command(client.users.get_user, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -149,7 +149,7 @@ def get_user_license(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "get_user_license", ctx, **kwargs)
+    result = run_command(client.users.get_user_license, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -163,7 +163,7 @@ def get_user_onboarding(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "get_user_onboarding", ctx, **kwargs)
+    result = run_command(client.users.get_user_onboarding, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -177,7 +177,7 @@ def search_users(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "search_users", ctx, **kwargs)
+    result = run_command(client.users.search_users, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -202,7 +202,7 @@ def set_user_license(
     license_key_dto = LicenseKeyDto.model_validate(json_data)
     kwargs["license_key_dto"] = license_key_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "set_user_license", ctx, **kwargs)
+    result = run_command(client.users.set_user_license, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -223,7 +223,7 @@ def set_user_onboarding(
     onboarding_dto = OnboardingDto.model_validate(json_data)
     kwargs["onboarding_dto"] = onboarding_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "set_user_onboarding", ctx, **kwargs)
+    result = run_command(client.users.set_user_onboarding, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -395,7 +395,7 @@ def update_my_preferences(
     user_preferences_update_dto = UserPreferencesUpdateDto.model_validate(json_data)
     kwargs["user_preferences_update_dto"] = user_preferences_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "update_my_preferences", ctx, **kwargs)
+    result = run_command(client.users.update_my_preferences, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -430,5 +430,5 @@ def update_my_user(
     user_update_me_dto = UserUpdateMeDto.model_validate(json_data)
     kwargs["user_update_me_dto"] = user_update_me_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users, "update_my_user", ctx, **kwargs)
+    result = run_command(client.users.update_my_user, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/users_admin.py
+++ b/immichpy/cli/commands/users_admin.py
@@ -80,7 +80,7 @@ Example: 123456""",
     user_admin_create_dto = UserAdminCreateDto.model_validate(json_data)
     kwargs["user_admin_create_dto"] = user_admin_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.create_user_admin, ctx, **kwargs)
+    result = run_command(client.users_admin.create_user_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def delete_user_admin(
     user_admin_delete_dto = UserAdminDeleteDto.model_validate(json_data)
     kwargs["user_admin_delete_dto"] = user_admin_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.delete_user_admin, ctx, **kwargs)
+    result = run_command(client.users_admin.delete_user_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def get_user_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.get_user_admin, ctx, **kwargs)
+    result = run_command(client.users_admin.get_user_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -138,7 +138,9 @@ def get_user_preferences_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.get_user_preferences_admin, ctx, **kwargs)
+    result = run_command(
+        client.users_admin.get_user_preferences_admin, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -156,7 +158,7 @@ def get_user_sessions_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.get_user_sessions_admin, ctx, **kwargs)
+    result = run_command(client.users_admin.get_user_sessions_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -189,7 +191,9 @@ def get_user_statistics_admin(
     if visibility is not None:
         kwargs["visibility"] = visibility
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.get_user_statistics_admin, ctx, **kwargs)
+    result = run_command(
+        client.users_admin.get_user_statistics_admin, ctx=ctx, **kwargs
+    )
     print_response(result, ctx)
 
 
@@ -205,7 +209,7 @@ def restore_user_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.restore_user_admin, ctx, **kwargs)
+    result = run_command(client.users_admin.restore_user_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -227,7 +231,7 @@ def search_users_admin(
     if with_deleted is not None:
         kwargs["with_deleted"] = with_deleted.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.search_users_admin, ctx, **kwargs)
+    result = run_command(client.users_admin.search_users_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -295,7 +299,7 @@ Example: 123456""",
     user_admin_update_dto = UserAdminUpdateDto.model_validate(json_data)
     kwargs["user_admin_update_dto"] = user_admin_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin.update_user_admin, ctx, **kwargs)
+    result = run_command(client.users_admin.update_user_admin, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -472,6 +476,6 @@ def update_user_preferences_admin(
     kwargs["user_preferences_update_dto"] = user_preferences_update_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.users_admin.update_user_preferences_admin, ctx, **kwargs
+        client.users_admin.update_user_preferences_admin, ctx=ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/users_admin.py
+++ b/immichpy/cli/commands/users_admin.py
@@ -80,7 +80,7 @@ Example: 123456""",
     user_admin_create_dto = UserAdminCreateDto.model_validate(json_data)
     kwargs["user_admin_create_dto"] = user_admin_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "create_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.create_user_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def delete_user_admin(
     user_admin_delete_dto = UserAdminDeleteDto.model_validate(json_data)
     kwargs["user_admin_delete_dto"] = user_admin_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "delete_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.delete_user_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def get_user_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "get_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.get_user_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -138,9 +138,7 @@ def get_user_preferences_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client.users_admin, "get_user_preferences_admin", ctx, **kwargs
-    )
+    result = run_command(client.users_admin.get_user_preferences_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -158,7 +156,7 @@ def get_user_sessions_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "get_user_sessions_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.get_user_sessions_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -191,7 +189,7 @@ def get_user_statistics_admin(
     if visibility is not None:
         kwargs["visibility"] = visibility
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "get_user_statistics_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.get_user_statistics_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -207,7 +205,7 @@ def restore_user_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "restore_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.restore_user_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -229,7 +227,7 @@ def search_users_admin(
     if with_deleted is not None:
         kwargs["with_deleted"] = with_deleted.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "search_users_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.search_users_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -297,7 +295,7 @@ Example: 123456""",
     user_admin_update_dto = UserAdminUpdateDto.model_validate(json_data)
     kwargs["user_admin_update_dto"] = user_admin_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users_admin, "update_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin.update_user_admin, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -474,6 +472,6 @@ def update_user_preferences_admin(
     kwargs["user_preferences_update_dto"] = user_preferences_update_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client.users_admin, "update_user_preferences_admin", ctx, **kwargs
+        client.users_admin.update_user_preferences_admin, ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/users_admin.py
+++ b/immichpy/cli/commands/users_admin.py
@@ -80,7 +80,7 @@ Example: 123456""",
     user_admin_create_dto = UserAdminCreateDto.model_validate(json_data)
     kwargs["user_admin_create_dto"] = user_admin_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users_admin, "create_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin, "create_user_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,7 +104,7 @@ def delete_user_admin(
     user_admin_delete_dto = UserAdminDeleteDto.model_validate(json_data)
     kwargs["user_admin_delete_dto"] = user_admin_delete_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users_admin, "delete_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin, "delete_user_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -120,7 +120,7 @@ def get_user_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users_admin, "get_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin, "get_user_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -139,7 +139,7 @@ def get_user_preferences_admin(
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.users_admin, "get_user_preferences_admin", ctx, **kwargs
+        client.users_admin, "get_user_preferences_admin", ctx, **kwargs
     )
     print_response(result, ctx)
 
@@ -158,9 +158,7 @@ def get_user_sessions_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.users_admin, "get_user_sessions_admin", ctx, **kwargs
-    )
+    result = run_command(client.users_admin, "get_user_sessions_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -193,9 +191,7 @@ def get_user_statistics_admin(
     if visibility is not None:
         kwargs["visibility"] = visibility
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.users_admin, "get_user_statistics_admin", ctx, **kwargs
-    )
+    result = run_command(client.users_admin, "get_user_statistics_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -211,9 +207,7 @@ def restore_user_admin(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.users_admin, "restore_user_admin", ctx, **kwargs
-    )
+    result = run_command(client.users_admin, "restore_user_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -235,9 +229,7 @@ def search_users_admin(
     if with_deleted is not None:
         kwargs["with_deleted"] = with_deleted.lower() == "true"
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.users_admin, "search_users_admin", ctx, **kwargs
-    )
+    result = run_command(client.users_admin, "search_users_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -305,7 +297,7 @@ Example: 123456""",
     user_admin_update_dto = UserAdminUpdateDto.model_validate(json_data)
     kwargs["user_admin_update_dto"] = user_admin_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.users_admin, "update_user_admin", ctx, **kwargs)
+    result = run_command(client.users_admin, "update_user_admin", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -482,6 +474,6 @@ def update_user_preferences_admin(
     kwargs["user_preferences_update_dto"] = user_preferences_update_dto
     client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.users_admin, "update_user_preferences_admin", ctx, **kwargs
+        client.users_admin, "update_user_preferences_admin", ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/commands/views.py
+++ b/immichpy/cli/commands/views.py
@@ -30,9 +30,7 @@ def get_assets_by_original_path(
     kwargs = {}
     kwargs["path"] = path
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.views, "get_assets_by_original_path", ctx, **kwargs
-    )
+    result = run_command(client.views, "get_assets_by_original_path", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -48,7 +46,5 @@ def get_unique_original_paths(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        client, client.views, "get_unique_original_paths", ctx, **kwargs
-    )
+    result = run_command(client.views, "get_unique_original_paths", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/views.py
+++ b/immichpy/cli/commands/views.py
@@ -30,7 +30,7 @@ def get_assets_by_original_path(
     kwargs = {}
     kwargs["path"] = path
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.views, "get_assets_by_original_path", ctx, **kwargs)
+    result = run_command(client.views.get_assets_by_original_path, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -46,5 +46,5 @@ def get_unique_original_paths(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.views, "get_unique_original_paths", ctx, **kwargs)
+    result = run_command(client.views.get_unique_original_paths, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/views.py
+++ b/immichpy/cli/commands/views.py
@@ -30,7 +30,7 @@ def get_assets_by_original_path(
     kwargs = {}
     kwargs["path"] = path
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.views.get_assets_by_original_path, ctx, **kwargs)
+    result = run_command(client.views.get_assets_by_original_path, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -46,5 +46,5 @@ def get_unique_original_paths(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.views.get_unique_original_paths, ctx, **kwargs)
+    result = run_command(client.views.get_unique_original_paths, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/workflows.py
+++ b/immichpy/cli/commands/workflows.py
@@ -62,7 +62,7 @@ As a JSON string""",
     workflow_create_dto = WorkflowCreateDto.model_validate(json_data)
     kwargs["workflow_create_dto"] = workflow_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows.create_workflow, ctx, **kwargs)
+    result = run_command(client.workflows.create_workflow, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -78,7 +78,7 @@ def delete_workflow(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows.delete_workflow, ctx, **kwargs)
+    result = run_command(client.workflows.delete_workflow, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -94,7 +94,7 @@ def get_workflow(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows.get_workflow, ctx, **kwargs)
+    result = run_command(client.workflows.get_workflow, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -108,7 +108,7 @@ def get_workflows(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows.get_workflows, ctx, **kwargs)
+    result = run_command(client.workflows.get_workflows, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -165,5 +165,5 @@ As a JSON string""",
     workflow_update_dto = WorkflowUpdateDto.model_validate(json_data)
     kwargs["workflow_update_dto"] = workflow_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows.update_workflow, ctx, **kwargs)
+    result = run_command(client.workflows.update_workflow, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/workflows.py
+++ b/immichpy/cli/commands/workflows.py
@@ -62,7 +62,7 @@ As a JSON string""",
     workflow_create_dto = WorkflowCreateDto.model_validate(json_data)
     kwargs["workflow_create_dto"] = workflow_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows, "create_workflow", ctx, **kwargs)
+    result = run_command(client.workflows.create_workflow, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -78,7 +78,7 @@ def delete_workflow(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows, "delete_workflow", ctx, **kwargs)
+    result = run_command(client.workflows.delete_workflow, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -94,7 +94,7 @@ def get_workflow(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows, "get_workflow", ctx, **kwargs)
+    result = run_command(client.workflows.get_workflow, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -108,7 +108,7 @@ def get_workflows(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows, "get_workflows", ctx, **kwargs)
+    result = run_command(client.workflows.get_workflows, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -165,5 +165,5 @@ As a JSON string""",
     workflow_update_dto = WorkflowUpdateDto.model_validate(json_data)
     kwargs["workflow_update_dto"] = workflow_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.workflows, "update_workflow", ctx, **kwargs)
+    result = run_command(client.workflows.update_workflow, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/commands/workflows.py
+++ b/immichpy/cli/commands/workflows.py
@@ -62,7 +62,7 @@ As a JSON string""",
     workflow_create_dto = WorkflowCreateDto.model_validate(json_data)
     kwargs["workflow_create_dto"] = workflow_create_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.workflows, "create_workflow", ctx, **kwargs)
+    result = run_command(client.workflows, "create_workflow", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -78,7 +78,7 @@ def delete_workflow(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.workflows, "delete_workflow", ctx, **kwargs)
+    result = run_command(client.workflows, "delete_workflow", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -94,7 +94,7 @@ def get_workflow(
     kwargs = {}
     kwargs["id"] = id
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.workflows, "get_workflow", ctx, **kwargs)
+    result = run_command(client.workflows, "get_workflow", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -108,7 +108,7 @@ def get_workflows(
     """
     kwargs = {}
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.workflows, "get_workflows", ctx, **kwargs)
+    result = run_command(client.workflows, "get_workflows", ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -165,5 +165,5 @@ As a JSON string""",
     workflow_update_dto = WorkflowUpdateDto.model_validate(json_data)
     kwargs["workflow_update_dto"] = workflow_update_dto
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.workflows, "update_workflow", ctx, **kwargs)
+    result = run_command(client.workflows, "update_workflow", ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/runtime.py
+++ b/immichpy/cli/runtime.py
@@ -96,8 +96,8 @@ async def run_async(coro: Awaitable[Any]) -> Any:
 
 
 def run_command(
-    api_group: _ApiGroup,
-    method_name: str,
+    api: _ApiGroup,
+    method: str,
     ctx: Context | None = None,
     **kwargs: Any,
 ) -> Any:
@@ -111,13 +111,13 @@ def run_command(
     :raises Exit: Raised with a CLI exit code when API or unexpected errors occur
     :raises AttributeError: If `method_name` is not present on `api_group`
     """
-    method: Callable[..., Awaitable[Any]] = getattr(api_group, method_name)
+    method: Callable[..., Awaitable[Any]] = getattr(api, method)
 
     async def _call_and_close() -> Any:
         try:
             return await method(**kwargs)
         finally:
-            await api_group.api_client.close()
+            await api.api_client.close()
 
     try:
         return asyncio.run(_call_and_close())

--- a/immichpy/cli/runtime.py
+++ b/immichpy/cli/runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import traceback
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Protocol
 
 from immichpy.cli.utils import print_
 from pydantic import BaseModel
@@ -13,8 +13,12 @@ from typer import Context, Exit
 
 from immichpy.cli.types import MaybeBaseModel
 
-from immichpy import AsyncClient
+from immichpy.client.generated.api_client import ApiClient
 from immichpy.client.generated.exceptions import ApiException
+
+
+class _ApiGroup(Protocol):
+    api_client: ApiClient
 
 
 def set_nested(d: dict[str, Any], path: list[str], value: Any) -> None:
@@ -92,15 +96,13 @@ async def run_async(coro: Awaitable[Any]) -> Any:
 
 
 def run_command(
-    client: AsyncClient,
-    api_group: Any,
+    api_group: _ApiGroup,
     method_name: str,
     ctx: Context | None = None,
     **kwargs: Any,
 ) -> Any:
     """Run a client API method and handle the result.
 
-    :param client: The async client instance to close after execution
     :param api_group: The API group object containing the target method
     :param method_name: The name of the method to invoke on `api_group`
     :param ctx: Optional Typer context for CLI output formatting
@@ -115,7 +117,7 @@ def run_command(
         try:
             return await method(**kwargs)
         finally:
-            await client.close()
+            await api_group.api_client.close()
 
     try:
         return asyncio.run(_call_and_close())

--- a/immichpy/cli/runtime.py
+++ b/immichpy/cli/runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import traceback
-from typing import Any, Awaitable, Callable, Protocol
+from typing import Any, Awaitable, Callable, Protocol, cast
 
 from immichpy.cli.utils import print_
 from pydantic import BaseModel
@@ -96,28 +96,24 @@ async def run_async(coro: Awaitable[Any]) -> Any:
 
 
 def run_command(
-    api: _ApiGroup,
-    method: str,
+    method: Callable[..., Awaitable[Any]],
     ctx: Context | None = None,
     **kwargs: Any,
 ) -> Any:
     """Run a client API method and handle the result.
 
-    :param api_group: The API group object containing the target method
-    :param method_name: The name of the method to invoke on `api_group`
+    :param method: Bound API method to invoke
     :param ctx: Optional Typer context for CLI output formatting
     :param kwargs: Keyword arguments forwarded to the API method
     :return: The API method return value
     :raises Exit: Raised with a CLI exit code when API or unexpected errors occur
-    :raises AttributeError: If `method_name` is not present on `api_group`
     """
-    method: Callable[..., Awaitable[Any]] = getattr(api, method)
 
     async def _call_and_close() -> Any:
         try:
             return await method(**kwargs)
         finally:
-            await api.api_client.close()
+            await cast(_ApiGroup, getattr(method, "__self__")).api_client.close()
 
     try:
         return asyncio.run(_call_and_close())

--- a/immichpy/cli/runtime.py
+++ b/immichpy/cli/runtime.py
@@ -97,6 +97,7 @@ async def run_async(coro: Awaitable[Any]) -> Any:
 
 def run_command(
     method: Callable[..., Awaitable[Any]],
+    *,
     ctx: Context | None = None,
     **kwargs: Any,
 ) -> Any:

--- a/immichpy/cli/wrapper/assets.py
+++ b/immichpy/cli/wrapper/assets.py
@@ -57,7 +57,7 @@ def download_asset_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.download_asset_to_file, ctx, **kwargs)
+    result = run_command(client.assets.download_asset_to_file, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -99,7 +99,7 @@ def play_asset_video_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.play_asset_video_to_file, ctx, **kwargs)
+    result = run_command(client.assets.play_asset_video_to_file, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -146,7 +146,7 @@ def view_asset_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.view_asset_to_file, ctx, **kwargs)
+    result = run_command(client.assets.view_asset_to_file, ctx=ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -219,5 +219,5 @@ def upload(
     kwargs["delete_duplicates"] = delete_duplicates
     kwargs["dry_run"] = dry_run
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.assets.upload, ctx, **kwargs)
+    result = run_command(client.assets.upload, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/assets.py
+++ b/immichpy/cli/wrapper/assets.py
@@ -57,12 +57,7 @@ def download_asset_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        api=client.assets,
-        method="download_asset_to_file",
-        ctx=ctx,
-        **kwargs,
-    )
+    result = run_command(client.assets.download_asset_to_file, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -104,12 +99,7 @@ def play_asset_video_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        api=client.assets,
-        method="play_asset_video_to_file",
-        ctx=ctx,
-        **kwargs,
-    )
+    result = run_command(client.assets.play_asset_video_to_file, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -156,12 +146,7 @@ def view_asset_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        api=client.assets,
-        method="view_asset_to_file",
-        ctx=ctx,
-        **kwargs,
-    )
+    result = run_command(client.assets.view_asset_to_file, ctx, **kwargs)
     print_response(result, ctx)
 
 
@@ -234,5 +219,5 @@ def upload(
     kwargs["delete_duplicates"] = delete_duplicates
     kwargs["dry_run"] = dry_run
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(api=client.assets, method="upload", ctx=ctx, **kwargs)
+    result = run_command(client.assets.upload, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/assets.py
+++ b/immichpy/cli/wrapper/assets.py
@@ -8,6 +8,10 @@ import typer
 
 from immichpy.cli.commands import assets as assets_commands
 from immichpy.cli.runtime import print_response, run_command
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from immichpy import AsyncClient
 
 # Reuse the existing app from the generated commands
 app = assets_commands.app
@@ -52,8 +56,9 @@ def download_asset_to_file(
         kwargs["slug"] = slug
     if filename is not None:
         kwargs["filename"] = filename
+    client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        api=ctx.obj["client"].assets,
+        api=client.assets,
         method="download_asset_to_file",
         ctx=ctx,
         **kwargs,
@@ -98,8 +103,9 @@ def play_asset_video_to_file(
         kwargs["slug"] = slug
     if filename is not None:
         kwargs["filename"] = filename
+    client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        api=ctx.obj["client"].assets,
+        api=client.assets,
         method="play_asset_video_to_file",
         ctx=ctx,
         **kwargs,
@@ -149,8 +155,9 @@ def view_asset_to_file(
         kwargs["size"] = size
     if filename is not None:
         kwargs["filename"] = filename
+    client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        api=ctx.obj["client"].assets,
+        api=client.assets,
         method="view_asset_to_file",
         ctx=ctx,
         **kwargs,
@@ -226,7 +233,6 @@ def upload(
     kwargs["delete_uploads"] = delete_uploads
     kwargs["delete_duplicates"] = delete_duplicates
     kwargs["dry_run"] = dry_run
-    result = run_command(
-        api=ctx.obj["client"].assets, method="upload", ctx=ctx, **kwargs
-    )
+    client: "AsyncClient" = ctx.obj["client"]
+    result = run_command(api=client.assets, method="upload", ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/assets.py
+++ b/immichpy/cli/wrapper/assets.py
@@ -53,8 +53,8 @@ def download_asset_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     result = run_command(
-        api_group=ctx.obj["client"].assets,
-        method_name="download_asset_to_file",
+        api=ctx.obj["client"].assets,
+        method="download_asset_to_file",
         ctx=ctx,
         **kwargs,
     )
@@ -99,8 +99,8 @@ def play_asset_video_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     result = run_command(
-        api_group=ctx.obj["client"].assets,
-        method_name="play_asset_video_to_file",
+        api=ctx.obj["client"].assets,
+        method="play_asset_video_to_file",
         ctx=ctx,
         **kwargs,
     )
@@ -150,8 +150,8 @@ def view_asset_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     result = run_command(
-        api_group=ctx.obj["client"].assets,
-        method_name="view_asset_to_file",
+        api=ctx.obj["client"].assets,
+        method="view_asset_to_file",
         ctx=ctx,
         **kwargs,
     )
@@ -227,6 +227,6 @@ def upload(
     kwargs["delete_duplicates"] = delete_duplicates
     kwargs["dry_run"] = dry_run
     result = run_command(
-        api_group=ctx.obj["client"].assets, method_name="upload", ctx=ctx, **kwargs
+        api=ctx.obj["client"].assets, method="upload", ctx=ctx, **kwargs
     )
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/assets.py
+++ b/immichpy/cli/wrapper/assets.py
@@ -6,13 +6,9 @@ from pathlib import Path
 
 import typer
 
-from typing import TYPE_CHECKING
-
 from immichpy.cli.commands import assets as assets_commands
 from immichpy.cli.runtime import print_response, run_command
 
-if TYPE_CHECKING:
-    from immichpy.client.main import AsyncClient
 # Reuse the existing app from the generated commands
 app = assets_commands.app
 
@@ -56,9 +52,11 @@ def download_asset_to_file(
         kwargs["slug"] = slug
     if filename is not None:
         kwargs["filename"] = filename
-    client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.assets, "download_asset_to_file", ctx=ctx, **kwargs
+        api_group=ctx.obj["client"].assets,
+        method_name="download_asset_to_file",
+        ctx=ctx,
+        **kwargs,
     )
     print_response(result, ctx)
 
@@ -100,9 +98,11 @@ def play_asset_video_to_file(
         kwargs["slug"] = slug
     if filename is not None:
         kwargs["filename"] = filename
-    client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        client, client.assets, "play_asset_video_to_file", ctx=ctx, **kwargs
+        api_group=ctx.obj["client"].assets,
+        method_name="play_asset_video_to_file",
+        ctx=ctx,
+        **kwargs,
     )
     print_response(result, ctx)
 
@@ -149,8 +149,12 @@ def view_asset_to_file(
         kwargs["size"] = size
     if filename is not None:
         kwargs["filename"] = filename
-    client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "view_asset_to_file", ctx=ctx, **kwargs)
+    result = run_command(
+        api_group=ctx.obj["client"].assets,
+        method_name="view_asset_to_file",
+        ctx=ctx,
+        **kwargs,
+    )
     print_response(result, ctx)
 
 
@@ -222,6 +226,7 @@ def upload(
     kwargs["delete_uploads"] = delete_uploads
     kwargs["delete_duplicates"] = delete_duplicates
     kwargs["dry_run"] = dry_run
-    client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client, client.assets, "upload", ctx=ctx, **kwargs)
+    result = run_command(
+        api_group=ctx.obj["client"].assets, method_name="upload", ctx=ctx, **kwargs
+    )
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/download.py
+++ b/immichpy/cli/wrapper/download.py
@@ -12,6 +12,10 @@ from immichpy.cli.runtime import (
     run_command,
     set_nested,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from immichpy import AsyncClient
 
 # Reuse the existing app from the generated commands
 app = download_commands.app
@@ -72,8 +76,9 @@ def download_archive_to_file(
     kwargs["slug"] = slug
     kwargs["show_progress"] = show_progress
 
+    client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        api=ctx.obj["client"].download,
+        api=client.download,
         method="download_archive_to_file",
         ctx=ctx,
         **kwargs,

--- a/immichpy/cli/wrapper/download.py
+++ b/immichpy/cli/wrapper/download.py
@@ -73,8 +73,8 @@ def download_archive_to_file(
     kwargs["show_progress"] = show_progress
 
     result = run_command(
-        api_group=ctx.obj["client"].download,
-        method_name="download_archive_to_file",
+        api=ctx.obj["client"].download,
+        method="download_archive_to_file",
         ctx=ctx,
         **kwargs,
     )

--- a/immichpy/cli/wrapper/download.py
+++ b/immichpy/cli/wrapper/download.py
@@ -72,8 +72,10 @@ def download_archive_to_file(
     kwargs["slug"] = slug
     kwargs["show_progress"] = show_progress
 
-    client = ctx.obj["client"]
     result = run_command(
-        client, client.download, "download_archive_to_file", ctx=ctx, **kwargs
+        api_group=ctx.obj["client"].download,
+        method_name="download_archive_to_file",
+        ctx=ctx,
+        **kwargs,
     )
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/download.py
+++ b/immichpy/cli/wrapper/download.py
@@ -77,10 +77,5 @@ def download_archive_to_file(
     kwargs["show_progress"] = show_progress
 
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        api=client.download,
-        method="download_archive_to_file",
-        ctx=ctx,
-        **kwargs,
-    )
+    result = run_command(client.download.download_archive_to_file, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/download.py
+++ b/immichpy/cli/wrapper/download.py
@@ -77,5 +77,5 @@ def download_archive_to_file(
     kwargs["show_progress"] = show_progress
 
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.download.download_archive_to_file, ctx, **kwargs)
+    result = run_command(client.download.download_archive_to_file, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/setup.py
+++ b/immichpy/cli/wrapper/setup.py
@@ -57,7 +57,7 @@ def setup(
             base_url=base_url, api_key=api_key, access_token=access_token
         )
         try:
-            run_command(api_group=client.server, method_name="ping_server", ctx=ctx)
+            run_command(api=client.server, method="ping_server", ctx=ctx)
         except Exception:
             print_(
                 "Error validating server. Make sure the base URL is correct (including /api) and the server is reachable.",

--- a/immichpy/cli/wrapper/setup.py
+++ b/immichpy/cli/wrapper/setup.py
@@ -57,7 +57,7 @@ def setup(
             base_url=base_url, api_key=api_key, access_token=access_token
         )
         try:
-            run_command(api=client.server, method="ping_server", ctx=ctx)
+            run_command(client.server.ping_server, ctx)
         except Exception:
             print_(
                 "Error validating server. Make sure the base URL is correct (including /api) and the server is reachable.",

--- a/immichpy/cli/wrapper/setup.py
+++ b/immichpy/cli/wrapper/setup.py
@@ -57,7 +57,7 @@ def setup(
             base_url=base_url, api_key=api_key, access_token=access_token
         )
         try:
-            run_command(client.server.ping_server, ctx)
+            run_command(client.server.ping_server, ctx=ctx)
         except Exception:
             print_(
                 "Error validating server. Make sure the base URL is correct (including /api) and the server is reachable.",

--- a/immichpy/cli/wrapper/setup.py
+++ b/immichpy/cli/wrapper/setup.py
@@ -57,7 +57,7 @@ def setup(
             base_url=base_url, api_key=api_key, access_token=access_token
         )
         try:
-            run_command(client, client.server, "ping_server", ctx=ctx)
+            run_command(api_group=client.server, method_name="ping_server", ctx=ctx)
         except Exception:
             print_(
                 "Error validating server. Make sure the base URL is correct (including /api) and the server is reachable.",

--- a/immichpy/cli/wrapper/users.py
+++ b/immichpy/cli/wrapper/users.py
@@ -48,10 +48,5 @@ def get_profile_image_to_file(
         kwargs["filename"] = filename
     kwargs["show_progress"] = show_progress
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(
-        api=client.users,
-        method="get_profile_image_to_file",
-        ctx=ctx,
-        **kwargs,
-    )
+    result = run_command(client.users.get_profile_image_to_file, ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/users.py
+++ b/immichpy/cli/wrapper/users.py
@@ -43,8 +43,8 @@ def get_profile_image_to_file(
         kwargs["filename"] = filename
     kwargs["show_progress"] = show_progress
     result = run_command(
-        api_group=ctx.obj["client"].users,
-        method_name="get_profile_image_to_file",
+        api=ctx.obj["client"].users,
+        method="get_profile_image_to_file",
         ctx=ctx,
         **kwargs,
     )

--- a/immichpy/cli/wrapper/users.py
+++ b/immichpy/cli/wrapper/users.py
@@ -42,8 +42,10 @@ def get_profile_image_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     kwargs["show_progress"] = show_progress
-    client = ctx.obj["client"]
     result = run_command(
-        client, client.users, "get_profile_image_to_file", ctx=ctx, **kwargs
+        api_group=ctx.obj["client"].users,
+        method_name="get_profile_image_to_file",
+        ctx=ctx,
+        **kwargs,
     )
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/users.py
+++ b/immichpy/cli/wrapper/users.py
@@ -48,5 +48,5 @@ def get_profile_image_to_file(
         kwargs["filename"] = filename
     kwargs["show_progress"] = show_progress
     client: "AsyncClient" = ctx.obj["client"]
-    result = run_command(client.users.get_profile_image_to_file, ctx, **kwargs)
+    result = run_command(client.users.get_profile_image_to_file, ctx=ctx, **kwargs)
     print_response(result, ctx)

--- a/immichpy/cli/wrapper/users.py
+++ b/immichpy/cli/wrapper/users.py
@@ -9,6 +9,11 @@ import typer
 from immichpy.cli.commands import users as users_commands
 from immichpy.cli.runtime import print_response, run_command
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from immichpy import AsyncClient
+
 # Reuse the existing app from the generated commands
 app = users_commands.app
 
@@ -42,8 +47,9 @@ def get_profile_image_to_file(
     if filename is not None:
         kwargs["filename"] = filename
     kwargs["show_progress"] = show_progress
+    client: "AsyncClient" = ctx.obj["client"]
     result = run_command(
-        api=ctx.obj["client"].users,
+        api=client.users,
         method="get_profile_image_to_file",
         ctx=ctx,
         **kwargs,

--- a/tests/unit/cli/test_runtime.py
+++ b/tests/unit/cli/test_runtime.py
@@ -175,7 +175,7 @@ class TestRunCommand:
         mock_asyncio_run.side_effect = mock_run
 
         result: dict[str, str] = run_command(
-            mock_client, mock_api_group, "test_method", None, arg1="value1"
+            mock_api_group, "test_method", None, arg1="value1"
         )
 
         assert result == {"result": "success"}
@@ -211,7 +211,7 @@ class TestRunCommand:
         ctx.obj = {"format": "json"}
 
         with pytest.raises(Exit) as exc_info:
-            run_command(mock_client, mock_api_group, "test_method", ctx)
+            run_command(mock_api_group, "test_method", ctx)
 
         assert exc_info.value.exit_code == 4
         mock_format_error.assert_called_once_with(api_error)
@@ -240,7 +240,7 @@ class TestRunCommand:
         mock_asyncio_run.side_effect = mock_run
 
         with pytest.raises(Exit) as exc_info:
-            run_command(mock_client, mock_api_group, "test_method", None)
+            run_command(mock_api_group, "test_method", None)
 
         assert exc_info.value.exit_code == 1
         mock_print.assert_any_call(

--- a/tests/unit/cli/test_runtime.py
+++ b/tests/unit/cli/test_runtime.py
@@ -179,7 +179,7 @@ class TestRunCommand:
 
         mock_asyncio_run.side_effect = mock_run
 
-        result: dict[str, str] = run_command(method, None, arg1="value1")
+        result: dict[str, str] = run_command(method, ctx=None, arg1="value1")
 
         assert result == {"result": "success"}
         mock_asyncio_run.assert_called_once()
@@ -209,7 +209,7 @@ class TestRunCommand:
         ctx.obj = {"format": "json"}
 
         with pytest.raises(Exit) as exc_info:
-            run_command(method, ctx)
+            run_command(method, ctx=ctx)
 
         assert exc_info.value.exit_code == 4
         mock_format_error.assert_called_once_with(api_error)
@@ -233,7 +233,7 @@ class TestRunCommand:
         mock_asyncio_run.side_effect = mock_run
 
         with pytest.raises(Exit) as exc_info:
-            run_command(method, None)
+            run_command(method, ctx=None)
 
         assert exc_info.value.exit_code == 1
         mock_print.assert_any_call(

--- a/tests/unit/cli/test_runtime.py
+++ b/tests/unit/cli/test_runtime.py
@@ -22,7 +22,6 @@ from immichpy.cli.runtime import (
     run_command,
 )
 from immichpy.client.generated.exceptions import ApiException
-from immichpy import AsyncClient
 
 
 class TestSetNested:
@@ -152,18 +151,24 @@ class TestRunAsync:
             await run_async(failing_coro())
 
 
+def _make_bound_method(return_value: Any = None, side_effect: Any = None) -> AsyncMock:
+    """Create an AsyncMock that looks like a bound method with an api_client."""
+    mock_api_client: MagicMock = MagicMock()
+    mock_api_client.close = AsyncMock()
+    mock_api_group: MagicMock = MagicMock()
+    mock_api_group.api_client = mock_api_client
+    method: AsyncMock = AsyncMock(return_value=return_value, side_effect=side_effect)
+    method.__self__ = mock_api_group
+    return method
+
+
 class TestRunCommand:
     """Tests for run_command function."""
 
     @patch("immichpy.cli.runtime.asyncio.run")
     def test_run_command_success(self, mock_asyncio_run: Mock) -> None:
         """Test run_command with successful execution."""
-        mock_client: Mock = Mock(spec=AsyncClient)
-        mock_client.close = AsyncMock()
-
-        mock_api_group: MagicMock = MagicMock()
-        mock_method: AsyncMock = AsyncMock(return_value={"result": "success"})
-        mock_api_group.test_method = mock_method
+        method = _make_bound_method(return_value={"result": "success"})
 
         def mock_run(coro: Any) -> Any:
             loop = asyncio.new_event_loop()
@@ -174,9 +179,7 @@ class TestRunCommand:
 
         mock_asyncio_run.side_effect = mock_run
 
-        result: dict[str, str] = run_command(
-            mock_api_group, "test_method", None, arg1="value1"
-        )
+        result: dict[str, str] = run_command(method, None, arg1="value1")
 
         assert result == {"result": "success"}
         mock_asyncio_run.assert_called_once()
@@ -188,14 +191,9 @@ class TestRunCommand:
         self, mock_asyncio_run: Mock, mock_format_error: Mock, mock_print: Mock
     ) -> None:
         """Test run_command with ApiException."""
-        mock_client: Mock = Mock(spec=AsyncClient)
-        mock_client.close = AsyncMock()
-
-        mock_api_group: MagicMock = MagicMock()
         api_error: ApiException = ApiException(status=404)
         api_error.body = {"error": "not found"}
-        mock_method: AsyncMock = AsyncMock(side_effect=api_error)
-        mock_api_group.test_method = mock_method
+        method = _make_bound_method(side_effect=api_error)
 
         def mock_run(coro: Any) -> Any:
             loop = asyncio.new_event_loop()
@@ -211,7 +209,7 @@ class TestRunCommand:
         ctx.obj = {"format": "json"}
 
         with pytest.raises(Exit) as exc_info:
-            run_command(mock_api_group, "test_method", ctx)
+            run_command(method, ctx)
 
         assert exc_info.value.exit_code == 4
         mock_format_error.assert_called_once_with(api_error)
@@ -223,12 +221,7 @@ class TestRunCommand:
         self, mock_asyncio_run: Mock, mock_print: Mock
     ) -> None:
         """Test run_command with non-ApiException."""
-        mock_client: Mock = Mock(spec=AsyncClient)
-        mock_client.close = AsyncMock()
-
-        mock_api_group: MagicMock = MagicMock()
-        mock_method: AsyncMock = AsyncMock(side_effect=ValueError("test error"))
-        mock_api_group.test_method = mock_method
+        method = _make_bound_method(side_effect=ValueError("test error"))
 
         def mock_run(coro: Any) -> Any:
             loop = asyncio.new_event_loop()
@@ -240,11 +233,10 @@ class TestRunCommand:
         mock_asyncio_run.side_effect = mock_run
 
         with pytest.raises(Exit) as exc_info:
-            run_command(mock_api_group, "test_method", None)
+            run_command(method, None)
 
         assert exc_info.value.exit_code == 1
         mock_print.assert_any_call(
             "Unexpected error: test error", type="error", ctx=None
         )
-
         mock_asyncio_run.assert_called_once()

--- a/tests/unit/cli/test_runtime.py
+++ b/tests/unit/cli/test_runtime.py
@@ -183,6 +183,7 @@ class TestRunCommand:
 
         assert result == {"result": "success"}
         mock_asyncio_run.assert_called_once()
+        method.__self__.api_client.close.assert_awaited_once()
 
     @patch("immichpy.cli.runtime.print_")
     @patch("immichpy.cli.runtime.format_api_error")
@@ -240,3 +241,4 @@ class TestRunCommand:
             "Unexpected error: test error", type="error", ctx=None
         )
         mock_asyncio_run.assert_called_once()
+        method.__self__.api_client.close.assert_awaited_once()


### PR DESCRIPTION
- **chore(deps): update dependency ty to >=0.0.40,<0.0.41**
- **enhance the overload**
- **pass ctx to run_command**
- **drop client arg from runtime call**
- **refactor argument naming in run_command**
- **always add type for context client**
- **drop api parameter from run_command**
- **make ctx positional only**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal CLI command execution architecture for improved maintainability and consistency across all API endpoint integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->