### PR TITLE
fix: add duplicate assets to album on upload

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,7 +90,6 @@ jobs:
 
       - name: Run e2e tests
         env:
-          IMMICH_URL: http://127.0.0.1:2285
           IMMICH_API_URL: http://127.0.0.1:2285/api
         run: mise run ci:test:e2e
 

--- a/immichpy/cli/runtime.py
+++ b/immichpy/cli/runtime.py
@@ -114,7 +114,9 @@ def run_command(
         try:
             return await method(**kwargs)
         finally:
-            await cast(_ApiGroup, getattr(method, "__self__")).api_client.close()
+            self_ = getattr(method, "__self__", None)
+            if self_ is not None:
+                await cast(_ApiGroup, self_).api_client.close()
 
     try:
         return asyncio.run(_call_and_close())

--- a/immichpy/client/utils/upload.py
+++ b/immichpy/client/utils/upload.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import sys
-from pydantic import StrictStr
 from statx import statx
 from datetime import datetime, timezone
 from pathlib import Path
@@ -377,7 +376,7 @@ async def upload_files(
 
 
 async def update_albums(
-    asset_ids: list[StrictStr],
+    asset_ids: list[str],
     album_name: str | None,
     albums_api: AlbumsApi,
 ) -> None:
@@ -402,7 +401,7 @@ async def update_albums(
         album_map[album_name] = album.id
 
     album_id = album_map[album_name]
-    asset_uuids = [UUID(str(entry)) for entry in asset_ids]
+    asset_uuids = [UUID(entry) for entry in asset_ids]
 
     for i in range(0, len(asset_uuids), 1000):
         batch = asset_uuids[i : i + 1000]

--- a/immichpy/client/utils/upload.py
+++ b/immichpy/client/utils/upload.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sys
+from pydantic import StrictStr
 from statx import statx
 from datetime import datetime, timezone
 from pathlib import Path
@@ -376,7 +377,7 @@ async def upload_files(
 
 
 async def update_albums(
-    uploaded: list[UploadedEntry],
+    asset_ids: list[StrictStr],
     album_name: str | None,
     albums_api: AlbumsApi,
 ) -> None:
@@ -388,7 +389,7 @@ async def update_albums(
 
     :return: None
     """
-    if not album_name or not uploaded:
+    if not album_name or not asset_ids:
         return
 
     all_albums = await albums_api.get_all_albums()
@@ -401,10 +402,10 @@ async def update_albums(
         album_map[album_name] = album.id
 
     album_id = album_map[album_name]
-    asset_ids = [UUID(str(entry.asset.id)) for entry in uploaded]
+    asset_uuids = [UUID(str(entry)) for entry in asset_ids]
 
-    for i in range(0, len(asset_ids), 1000):
-        batch = asset_ids[i : i + 1000]
+    for i in range(0, len(asset_uuids), 1000):
+        batch = asset_uuids[i : i + 1000]
         await albums_api.add_assets_to_album(
             id=UUID(str(album_id)), bulk_ids_dto=BulkIdsDto(ids=batch)
         )

--- a/immichpy/client/wrapper/assets_api_wrapped.py
+++ b/immichpy/client/wrapper/assets_api_wrapped.py
@@ -18,7 +18,7 @@ from immichpy.client.utils.upload import (
     upload_files,
 )
 from immichpy.client.utils.download import download_file, resolve_output_filename
-from immichpy.client.types import HeadersType, UploadResult, UploadStats
+from immichpy.client.types import HeadersType, RejectionReason, UploadResult, UploadStats
 
 
 class AssetsApiWrapped(AssetsApi):
@@ -226,7 +226,18 @@ class AssetsApiWrapped(AssetsApi):
 
         if album_name and not dry_run:
             await update_albums(
-                uploaded=uploaded, album_name=album_name, albums_api=albums_api
+                asset_ids=[ent.asset.id for ent in uploaded], album_name=album_name, albums_api=albums_api
+            )
+            dup_reason: RejectionReason = "duplicate"
+            await update_albums(
+                asset_ids=[
+                    ent.asset_id
+                    for ent in [*checked_rejected, *actual_rejected]
+                    if ent.asset_id is not None
+                    and ent.reason == dup_reason
+                ],
+                album_name=album_name,
+                albums_api=albums_api,
             )
 
         # we can either check pre-upload rejected files or on-upload rejected files, so we return the appropriate list

--- a/immichpy/client/wrapper/assets_api_wrapped.py
+++ b/immichpy/client/wrapper/assets_api_wrapped.py
@@ -18,7 +18,7 @@ from immichpy.client.utils.upload import (
     upload_files,
 )
 from immichpy.client.utils.download import download_file, resolve_output_filename
-from immichpy.client.types import HeadersType, RejectionReason, UploadResult, UploadStats
+from immichpy.client.types import HeadersType, UploadResult, UploadStats
 
 
 class AssetsApiWrapped(AssetsApi):
@@ -225,17 +225,14 @@ class AssetsApiWrapped(AssetsApi):
         )
 
         if album_name and not dry_run:
+            uploaded_ids = [ent.asset.id for ent in uploaded]
+            duplicate_ids = [
+                ent.asset_id
+                for ent in [*checked_rejected, *actual_rejected]
+                if ent.asset_id is not None and ent.reason == "duplicate"
+            ]
             await update_albums(
-                asset_ids=[ent.asset.id for ent in uploaded], album_name=album_name, albums_api=albums_api
-            )
-            dup_reason: RejectionReason = "duplicate"
-            await update_albums(
-                asset_ids=[
-                    ent.asset_id
-                    for ent in [*checked_rejected, *actual_rejected]
-                    if ent.asset_id is not None
-                    and ent.reason == dup_reason
-                ],
+                asset_ids=uploaded_ids + duplicate_ids,
                 album_name=album_name,
                 albums_api=albums_api,
             )

--- a/tests/e2e/client/test_wrappers.py
+++ b/tests/e2e/client/test_wrappers.py
@@ -10,7 +10,9 @@ import pytest
 
 from immichpy import AsyncClient
 from immichpy.client.types import UploadResult
+from immichpy.client.generated.models.album_response_dto import AlbumResponseDto
 from immichpy.client.generated.models.asset_media_size import AssetMediaSize
+from immichpy.client.generated.models.create_album_dto import CreateAlbumDto
 from immichpy.client.generated.models.download_info_dto import DownloadInfoDto
 
 
@@ -34,6 +36,35 @@ async def test_assets_upload(
     assert len(result.uploaded) == 2
     assert len(result.rejected) == 0
     assert len(result.failed) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_assets_upload_duplicate_added_to_album(
+    test_image: Path,
+    upload_assets: Callable[..., Awaitable[UploadResult]],
+    album_factory: Callable[..., Awaitable[AlbumResponseDto]],
+    client_with_api_key: AsyncClient,
+):
+    """Test that duplicate assets are still added to the specified album."""
+    first_result = await upload_assets([test_image], show_progress=False)
+    assert len(first_result.uploaded) == 1
+    asset_id = UUID(first_result.uploaded[0].asset.id)
+
+    album = await album_factory(
+        CreateAlbumDto(albumName="Dupe Test Album").model_dump()
+    )
+    album_id = UUID(str(album.id))
+
+    second_result = await upload_assets(
+        [test_image], album_name="Dupe Test Album", show_progress=False
+    )
+    assert len(second_result.rejected) == 1
+    assert second_result.rejected[0].reason == "duplicate"
+
+    album_info = await client_with_api_key.albums.get_album_info(id=album_id)
+    album_asset_ids = {UUID(a.id) for a in album_info.assets}
+    assert asset_id in album_asset_ids
 
 
 @pytest.mark.asyncio

--- a/tests/unit/client/test_upload.py
+++ b/tests/unit/client/test_upload.py
@@ -553,7 +553,7 @@ async def test_update_albums_no_album_name(
     """Test that update_albums returns early when album_name is None."""
     uploaded_entry = uploaded_entry_factory()
     uploaded_entry.asset.id = "asset-1"
-    await update_albums([uploaded_entry], None, mock_albums_api)
+    await update_albums([uploaded_entry.asset.id], None, mock_albums_api)
     mock_albums_api.get_all_albums.assert_not_called()
     mock_albums_api.create_album.assert_not_called()
     mock_albums_api.add_assets_to_album.assert_not_called()
@@ -579,7 +579,7 @@ async def test_update_albums_existing_album(
         album_name="My Album", id=str(album_id)
     )
     mock_albums_api.get_all_albums.return_value = [existing_album]
-    await update_albums([uploaded_entry], "My Album", mock_albums_api)
+    await update_albums([uploaded_entry.asset.id], "My Album", mock_albums_api)
     mock_albums_api.get_all_albums.assert_called_once()
     mock_albums_api.create_album.assert_not_called()
     mock_albums_api.add_assets_to_album.assert_called_once()
@@ -600,7 +600,7 @@ async def test_update_albums_create_new_album(
     )
     mock_albums_api.get_all_albums.return_value = []
     mock_albums_api.create_album.return_value = new_album
-    await update_albums([uploaded_entry], "New Album", mock_albums_api)
+    await update_albums([uploaded_entry.asset.id], "New Album", mock_albums_api)
     mock_albums_api.get_all_albums.assert_called_once()
     mock_albums_api.create_album.assert_called_once()
     mock_albums_api.add_assets_to_album.assert_called_once()
@@ -621,7 +621,7 @@ async def test_update_albums_batching(
         album_name="Large Album", id=str(album_id)
     )
     mock_albums_api.get_all_albums.return_value = [existing_album]
-    await update_albums(uploaded_entries, "Large Album", mock_albums_api)
+    await update_albums([ent.asset.id for ent in uploaded_entries], "Large Album", mock_albums_api)
     assert mock_albums_api.add_assets_to_album.call_count == 2
     first_call = mock_albums_api.add_assets_to_album.call_args_list[0]
     second_call = mock_albums_api.add_assets_to_album.call_args_list[1]

--- a/tests/unit/client/test_upload.py
+++ b/tests/unit/client/test_upload.py
@@ -621,7 +621,9 @@ async def test_update_albums_batching(
         album_name="Large Album", id=str(album_id)
     )
     mock_albums_api.get_all_albums.return_value = [existing_album]
-    await update_albums([ent.asset.id for ent in uploaded_entries], "Large Album", mock_albums_api)
+    await update_albums(
+        [ent.asset.id for ent in uploaded_entries], "Large Album", mock_albums_api
+    )
     assert mock_albums_api.add_assets_to_album.call_count == 2
     first_call = mock_albums_api.add_assets_to_album.call_args_list[0]
     second_call = mock_albums_api.add_assets_to_album.call_args_list[1]


### PR DESCRIPTION
When I run
```
immichpy assets upload --album-name "XYZ" ...
```
and some files are rejected as duplicates, I would expect them to still be added to the album. Based on my (limited) understanding and testing, this PR makes that change. I changed the default behavior (because I viewed the current behavior as a bug), and I changed the interface of `update_albums`. If you object to either of those, I can fix that.

Thanks for immichpy!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate-rejected assets can now be added to specified albums during uploads.

* **Refactor**
  * Improved album assignment mechanism for uploaded assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->