### PR TITLE
feat: retry uploads on transient errors

### DIFF
--- a/immichpy/cli/wrapper/assets.py
+++ b/immichpy/cli/wrapper/assets.py
@@ -176,6 +176,11 @@ def upload(
     concurrency: int = typer.Option(
         5, "--concurrency", help="Number of concurrent uploads"
     ),
+    retries: int = typer.Option(
+        3,
+        "--retries",
+        help="Max upload attempts per file on transient (5xx/connection) errors. Set to 1 to disable.",
+    ),
     show_progress: bool = typer.Option(
         False, "--show-progress", help="Show progress bars"
     ),
@@ -214,6 +219,7 @@ def upload(
     kwargs["include_hidden"] = include_hidden
     kwargs["skip_duplicates"] = skip_duplicates
     kwargs["concurrency"] = concurrency
+    kwargs["retries"] = retries
     kwargs["show_progress"] = show_progress
     kwargs["delete_uploads"] = delete_uploads
     kwargs["delete_duplicates"] = delete_duplicates

--- a/immichpy/client/utils/upload.py
+++ b/immichpy/client/utils/upload.py
@@ -14,6 +14,8 @@ from typing import cast
 from uuid import UUID
 import uuid
 
+import tenacity
+from aiohttp import ClientConnectionError
 from rich.progress import (
     Progress,
     SpinnerColumn,
@@ -51,6 +53,23 @@ from immichpy.client.generated.exceptions import ApiException
 logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 5000
+
+# Immich emits no 429, so only transient server errors and dropped connections
+# are worth retrying. 4xx are not transient and fail fast. The upload POST is
+# safe to retry because the server deduplicates by checksum.
+RETRY_STATUSES = frozenset({500, 502, 503, 504})
+
+
+def _is_retryable_upload_error(exc: BaseException) -> bool:
+    """Return whether an upload error is transient and worth retrying.
+
+    :param exc: The exception raised by the upload call.
+
+    :return: True for retryable 5xx responses and connection errors.
+    """
+    if isinstance(exc, ApiException):
+        return exc.status in RETRY_STATUSES
+    return isinstance(exc, (ClientConnectionError, asyncio.TimeoutError))
 
 
 def get_device_asset_id(filepath: Path, stats: os.stat_result) -> str:
@@ -249,12 +268,14 @@ async def upload_file(
     filepath: Path,
     assets_api: AssetsApi,
     dry_run: bool = False,
+    retries: int = 3,
 ) -> ApiResponse[AssetMediaResponseDto]:
     """Upload a single asset file to the server.
 
     :param filepath: Path to the file to upload.
     :param assets_api: Assets API instance for upload.
     :param dry_run: Return mock response without actual upload.
+    :param retries: Maximum number of upload attempts on transient errors (>= 1).
 
     :return: API response containing the uploaded asset metadata.
     """
@@ -280,7 +301,14 @@ async def upload_file(
 
     file_created_at, file_modified_at = get_file_times(filepath, stats)
 
-    response = await assets_api.upload_asset_with_http_info(
+    retryer = tenacity.AsyncRetrying(
+        retry=tenacity.retry_if_exception(_is_retryable_upload_error),
+        stop=tenacity.stop_after_attempt(retries),
+        wait=tenacity.wait_exponential_jitter(initial=0.1, max=5.0),
+        reraise=True,
+    )
+    return await retryer(
+        assets_api.upload_asset_with_http_info,
         asset_data=asset_data,
         device_asset_id=get_device_asset_id(filepath, stats),
         device_id=DEVICE_ID,
@@ -288,7 +316,6 @@ async def upload_file(
         file_modified_at=file_modified_at,
         sidecar_data=sidecar_data,
     )
-    return response
 
 
 async def upload_files(
@@ -297,6 +324,7 @@ async def upload_files(
     concurrency: int = 5,
     show_progress: bool = False,
     dry_run: bool = False,
+    retries: int = 3,
 ) -> tuple[list[UploadedEntry], list[RejectedEntry], list[FailedEntry]]:
     """Upload multiple asset files concurrently.
 
@@ -305,6 +333,7 @@ async def upload_files(
     :param concurrency: Maximum number of concurrent uploads.
     :param show_progress: Whether to show upload progress bar.
     :param dry_run: Simulate uploads without actual API calls.
+    :param retries: Maximum number of upload attempts per file on transient errors (>= 1).
 
     :return: Tuple of (uploaded_entries, rejected_entries, failed_entries).
     """
@@ -333,7 +362,7 @@ async def upload_files(
         async def upload_with_semaphore(filepath: Path) -> None:
             async with semaphore:
                 try:
-                    response = await upload_file(filepath, assets_api, dry_run)
+                    response = await upload_file(filepath, assets_api, dry_run, retries)
                     if response.status_code == 201:
                         uploaded.append(
                             UploadedEntry(asset=response.data, filepath=filepath)

--- a/immichpy/client/wrapper/assets_api_wrapped.py
+++ b/immichpy/client/wrapper/assets_api_wrapped.py
@@ -195,6 +195,8 @@ class AssetsApiWrapped(AssetsApi):
         """
         if concurrency < 1:
             raise ValueError("concurrency must be >= 1")
+        if retries < 1:
+            raise ValueError("retries must be >= 1")
         server_api = ServerApi(self.api_client)
         albums_api = AlbumsApi(self.api_client)
 

--- a/immichpy/client/wrapper/assets_api_wrapped.py
+++ b/immichpy/client/wrapper/assets_api_wrapped.py
@@ -170,6 +170,7 @@ class AssetsApiWrapped(AssetsApi):
         include_hidden: bool = False,
         skip_duplicates: bool = False,
         concurrency: int = 5,
+        retries: int = 3,
         show_progress: bool = False,
         album_name: str | None = None,
         delete_uploads: bool = False,
@@ -184,6 +185,7 @@ class AssetsApiWrapped(AssetsApi):
         :param include_hidden: Whether to include hidden files (starting with ".").
         :param skip_duplicates: Whether to skip duplicate checking (might still get rejected on the server).
         :param concurrency: Number of concurrent uploads. Defaults to 5. A higher number may increase upload speed, but also increases the risk of rate limiting or other issues.
+        :param retries: Maximum number of upload attempts per file on transient errors (5xx and connection errors). Defaults to 3. Set to 1 to disable retrying. Safe to retry because the server deduplicates by checksum.
         :param show_progress: Whether to show progress bars.
         :param album_name: Album name to create or use. If None, no album operations are performed.
         :param delete_uploads: Whether to delete successfully uploaded files locally.
@@ -222,6 +224,7 @@ class AssetsApiWrapped(AssetsApi):
             concurrency=concurrency,
             show_progress=show_progress,
             dry_run=dry_run,
+            retries=retries,
         )
 
         if album_name and not dry_run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pystatx>=0.1,<0.2",
     "python-dateutil>=2.8.2,<3.0.0",
     "rich>=13.0.0,<16.0.0",
+    "tenacity>=9.0.0,<10.0.0",
     "typing-extensions>=4.0.0,<5.0.0",
 ]
 

--- a/tests/unit/client/test_upload.py
+++ b/tests/unit/client/test_upload.py
@@ -407,6 +407,43 @@ async def test_upload_file_with_sidecar(mock_assets, tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_upload_file_retries_on_transient_error(
+    mock_assets, tmp_path: Path
+) -> None:
+    """Test that a transient 5xx error is retried until it succeeds."""
+    file1 = tmp_path / "test1.jpg"
+    file1.write_bytes(b"test1")
+    mock_response = ApiResponse(
+        status_code=201,
+        headers=None,
+        data=AssetMediaResponseDto(id="asset-123", status=AssetMediaStatus.CREATED),
+        raw_data=b"",
+    )
+    mock_assets.upload_asset_with_http_info.side_effect = [
+        ApiException(status=503, reason="Service Unavailable"),
+        mock_response,
+    ]
+    result = await upload_file(file1, mock_assets, retries=3)
+    assert result == mock_response
+    assert mock_assets.upload_asset_with_http_info.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_upload_file_no_retry_on_client_error(
+    mock_assets, tmp_path: Path
+) -> None:
+    """Test that a 4xx error fails fast without retrying."""
+    file1 = tmp_path / "test1.jpg"
+    file1.write_bytes(b"test1")
+    mock_assets.upload_asset_with_http_info.side_effect = ApiException(
+        status=400, reason="Bad Request"
+    )
+    with pytest.raises(ApiException):
+        await upload_file(file1, mock_assets, retries=3)
+    assert mock_assets.upload_asset_with_http_info.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_upload_files_empty_list(mock_assets) -> None:
     """Test that empty files list returns empty results."""
     uploaded, rejected, failed = await upload_files([], mock_assets)

--- a/uv.lock
+++ b/uv.lock
@@ -535,6 +535,7 @@ dependencies = [
     { name = "pystatx" },
     { name = "python-dateutil" },
     { name = "rich" },
+    { name = "tenacity" },
     { name = "typing-extensions" },
 ]
 
@@ -572,6 +573,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0.0" },
     { name = "rich", specifier = ">=13.0.0,<16.0.0" },
     { name = "rtoml", marker = "extra == 'cli'", specifier = ">=0.13.0,<0.14.0" },
+    { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.26.3,<0.27.0" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5.0.0" },
     { name = "uv", marker = "extra == 'build'", specifier = "==0.11.17" },
@@ -1625,6 +1627,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Retries 3 times by default on non-client errors. Safe because the server deduplicates by
checksum; persistent failures still surface as FailedEntry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--retries` option for uploads, letting you control how many times a file is retried after transient failures.
  * Uploads now automatically retry certain temporary connection/server errors before giving up.

* **Bug Fixes**
  * Improved reliability for large or unstable uploads by handling transient failures more gracefully.

* **Tests**
  * Added coverage for retry behavior on temporary errors and fast failure on non-retryable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->